### PR TITLE
chore: remove deprecated Chrome no-sandbox flag

### DIFF
--- a/autogpt/commands/web_selenium.py
+++ b/autogpt/commands/web_selenium.py
@@ -136,7 +136,6 @@ def scrape_text_with_selenium(url: str, agent: Agent) -> tuple[WebDriver, str]:
             options.add_argument("--disable-dev-shm-usage")
             options.add_argument("--remote-debugging-port=9222")
 
-        options.add_argument("--no-sandbox")
         if agent.config.selenium_headless:
             options.add_argument("--headless=new")
             options.add_argument("--disable-gpu")


### PR DESCRIPTION
## Summary
- drop `--no-sandbox` Chrome option from Selenium setup

## Testing
- `su testuser -c '/usr/bin/python3 /tmp/test_script2.py'`
- `pytest tests/integration/test_web_selenium.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3b9474e0832f99ea73f7050230ac