### PR TITLE
feat: enable local command execution by default

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -119,9 +119,7 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     # Web browsing
     selenium_web_browser: str = "chrome"
     selenium_headless: bool = True
-    user_agent: str = (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
-    )
+    user_agent: str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
 
     ###################
     # Plugin Settings #
@@ -276,7 +274,7 @@ class ConfigBuilder(Configurable[Config]):
             "openai_api_key": os.getenv("OPENAI_API_KEY"),
             "use_azure": os.getenv("USE_AZURE") == "True",
             "azure_config_file": os.getenv("AZURE_CONFIG_FILE", AZURE_CONFIG_FILE),
-            "execute_local_commands": os.getenv("EXECUTE_LOCAL_COMMANDS", "False")
+            "execute_local_commands": os.getenv("EXECUTE_LOCAL_COMMANDS", "True")
             == "True",
             "restrict_to_workspace": os.getenv("RESTRICT_TO_WORKSPACE", "True")
             == "True",

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -15,7 +15,7 @@ Configuration is controlled through the `Config` object. You can set configurati
 - `ELEVENLABS_API_KEY`: ElevenLabs API Key. Optional.
 - `ELEVENLABS_VOICE_ID`: ElevenLabs Voice ID. Optional.
 - `EMBEDDING_MODEL`: LLM Model to use for embedding tasks. Default: text-embedding-ada-002
-- `EXECUTE_LOCAL_COMMANDS`: If shell commands should be executed locally. Default: False
+- `EXECUTE_LOCAL_COMMANDS`: If shell commands should be executed locally. Default: True
 - `EXIT_KEY`: Exit key accepted to exit. Default: n
 - `FAST_LLM`: LLM Model to use for most tasks. Default: gpt-3.5-turbo
 - `GITHUB_API_KEY`: [Github API Key](https://github.com/settings/tokens). Optional.


### PR DESCRIPTION
## Summary
- default execute local commands setting to True
- document EXECUTE_LOCAL_COMMANDS option's True default

## Testing
- `pre-commit run --files autogpt/config/config.py docs/configuration/options.md` *(fails: mypy errors, autoflake not installed, pytest-check invocation error)*
- `pytest tests/unit/test_config.py` *(fails: openai.AuthenticationError: Incorrect API key provided)*

------
https://chatgpt.com/codex/tasks/task_e_688f470c6d64832f86988eb6b9943df9