### PR TITLE
docs: translate plugin and testing docs to Chinese

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,8 +1,8 @@
-## Plugins
+## 插件
 
-⚠️💀 **WARNING** 💀⚠️: Review the code of any plugin you use thoroughly, as plugins can execute any Python code, potentially leading to malicious activities, such as stealing your API keys.
+⚠️💀 **警告** 💀⚠️：使用任何插件前请仔细审查其代码，因为插件可以执行任意 Python 代码，可能导致恶意活动，例如窃取你的 API 密钥。
 
-To configure plugins, you can create or edit the `plugins_config.yaml` file in the root directory of Auto-GPT. This file allows you to enable or disable plugins as desired. For specific configuration instructions, please refer to the documentation provided for each plugin. The file should be formatted in YAML. Here is an example for your reference:
+要配置插件，你可以在 Auto-GPT 根目录创建或编辑 `plugins_config.yaml` 文件。该文件允许你根据需要启用或禁用插件。具体配置说明请参阅各插件提供的文档。该文件应以 YAML 格式编写。以下是一个示例：
 
 ```yaml
 plugin_a:
@@ -14,25 +14,18 @@ plugin_b:
   enabled: true
 ```
 
-See our [Plugins Repo](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) for more info on how to install all the amazing plugins the community has built!
+请参阅我们的 [插件仓库](https://github.com/Significant-Gravitas/Auto-GPT-Plugins)，了解如何安装社区构建的所有精彩插件！
 
-Alternatively, developers can use the [Auto-GPT Plugin Template](https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template) as a starting point for creating your own plugins.
+或者，开发者可以使用 [Auto-GPT 插件模板](https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template) 作为创建自己插件的起点。
 
-### Automatically filling plugin gaps
+### 自动填补插件缺口
 
-When the agent encounters a command that returns the special result `NEED_TOOL` (or
-repeated errors) the `PluginTodoQueue` increments a counter for that command. After
-three consecutive failures the counter is reset, the missing capability is written
-to a persistent TODO queue and a `plugin_gap` event is fired on the event bus. This
-mechanism lets you capture functionality that Auto‑GPT needed but could not
-complete.
+当代理遇到返回特殊结果 `NEED_TOOL`（或重复错误）的命令时，`PluginTodoQueue` 会为该命令增加计数器。经过三次连续失败后，计数器将被重置，缺失的功能被写入持久化的 TODO 队列，并在事件总线上触发 `plugin_gap` 事件。该机制能捕获 Auto‑GPT 需要但无法完成的功能。
 
-#### Generating plugins from gaps
+#### 从缺口生成插件
 
-1. Inspect the queue file (for example `todo_queue.json`) or subscribe to the
-   event bus to discover reported gaps.
-2. Create a specification for the new tool under `plugins/stubs/` as
-   `<name>.spec.json`:
+1. 检查队列文件（例如 `todo_queue.json`）或订阅事件总线以发现报告的缺口。
+2. 在 `plugins/stubs/` 下为新工具创建规范，命名为 `<name>.spec.json`：
 
    ```json
    {
@@ -41,21 +34,18 @@ complete.
    }
    ```
 
-3. Turn the specs into Python modules by running:
+3. 运行以下命令将规范转换为 Python 模块：
 
    ```bash
    python scripts/generate_plugins.py
    ```
 
-   If `OPENAI_API_KEY` is set the script will ask the API to implement the
-   plugin, otherwise it writes a simple stub.
-4. Reload the plugin registry by restarting Auto‑GPT (or calling
-   `scan_plugins`), which regenerates `plugin_registry.json` and activates the
-   generated plugin.
+   如果设置了 `OPENAI_API_KEY`，脚本会请求 API 实现插件，否则会写入一个简单的存根。
+4. 通过重启 Auto‑GPT（或调用 `scan_plugins`）重新加载插件注册表，这会重新生成 `plugin_registry.json` 并激活生成的插件。
 
-#### Enabling the queue
+#### 启用队列
 
-To start capturing plugin gaps, instantiate the queue and pass it to your agent:
+要开始捕获插件缺口，实例化队列并将其传递给代理：
 
 ```python
 from autogpt.event_bus import EventBus
@@ -67,6 +57,5 @@ plugin_queue = PluginTodoQueue("todo_queue.json", event_bus)
 agent = Agent(..., plugin_queue=plugin_queue)
 ```
 
-With this configuration, every repeated `NEED_TOOL` failure queues a todo item and
-emits a `plugin_gap` event, enabling an iterative plugin generation pipeline.
+通过此配置，每次重复的 `NEED_TOOL` 失败都会排入一个待办项并发出 `plugin_gap` 事件，从而启用迭代的插件生成管道。
 

--- a/docs/share-your-logs.md
+++ b/docs/share-your-logs.md
@@ -1,48 +1,44 @@
-## Share your logs with us to help improve Auto-GPT
+## 与我们分享日志以帮助改进 Auto-GPT
 
-Do you notice weird behavior with your agent? Do you have an interesting use case? Do you have a bug you want to report?
-Follow the steps below to enable your logs and upload them. You can include these logs when making an issue report or discussing an issue with us.
+你是否注意到代理出现奇怪行为？是否有有趣的用例？是否有想报告的 bug？按照以下步骤启用日志并上传。在提交问题报告或与我们讨论问题时，你可以附上这些日志。
 
-### Enable Debug Logs
-Activity, Error, and Debug logs are located in `./logs`
+### 启用调试日志
+活动、错误和调试日志位于 `./logs`
 
-To print out debug logs:
+打印调试日志：
 
 ```shell
 agpt --debug
 ```
 
-### Inspect and share logs
-You can inspect and share logs via [e2b](https://e2b.dev).
+### 检查并分享日志
+你可以通过 [e2b](https://e2b.dev) 检查和分享日志。
 ![E2b logs dashboard](./imgs/e2b-dashboard.png)
 
-
-
-1. Go to [autogpt.e2b.dev](https://autogpt.e2b.dev) and sign in.
-2. You'll see logs from other members of the AutoGPT team that you can inspect.
-3. Or you upload your own logs. Click on the "Upload log folder" button and select the debug logs dir that you generated. Wait a 1-2 seconds and the page reloads.
-4. You can share logs via sharing the URL in your browser.
+1. 访问 [autogpt.e2b.dev](https://autogpt.e2b.dev) 并登录。
+2. 你会看到 AutoGPT 团队其他成员的日志，可供检查。
+3. 或者上传你自己的日志。点击“Upload log folder”按钮并选择你生成的调试日志目录。等待 1-2 秒，页面会重新加载。
+4. 你可以通过分享浏览器中的 URL 来分享日志。
 ![E2b log URL](./imgs/e2b-log-url.png)
 
+### 为日志添加标签
+你可以为日志添加自定义标签供团队其他成员使用。如果你想指示代理例如在挑战任务中遇到问题，这会很有用。
 
-### Add tags to logs
-You can add custom tags to logs for other members of your team. This is useful if you want to indicate that the agent is for example having issues with challenges.
+E2b 提供 3 种严重程度：
 
-E2b offers 3 types of severity:
+- Success（成功）
+- Warning（警告）
+- Error（错误）
 
-- Success
-- Warning
-- Error
+你可以按任何方式命名你的标签。
 
-You can name your tag any way you want.
-
-#### How to add a tag
-1. Click on the "plus" button on the left from the logs folder name.
+#### 如何添加标签
+1. 点击日志文件夹名称左侧的“plus”按钮。
 
 ![E2b tag button](./imgs/e2b-tag-button.png)
 
-2. Type the name of a new tag.
+2. 输入新标签的名称。
 
-3. Select the severity.
+3. 选择严重程度。
 
 ![E2b new tag](./imgs/e2b-new-tag.png)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,56 +1,56 @@
-# Running tests
+# 运行测试
 
-Install the test and type-checking dependencies first:
+首先安装测试和类型检查依赖：
 
 ```shell
 pip install .[test,dev]  # includes test tools and type stubs
 ```
 
-To run all tests, use the following command:
+要运行所有测试，使用以下命令：
 
 ```shell
 pytest
 ```
 
-If `pytest` is not found:
+如果找不到 `pytest`：
 
 ```shell
 python -m pytest
 ```
 
-### Running specific test suites
+### 运行特定测试套件
 
-- To run without integration tests:
+- 不运行集成测试：
 
 ```shell
 pytest --without-integration
 ```
 
-- To run without *slow* integration tests:
+- 不运行 *慢速* 集成测试：
 
 ```shell
 pytest --without-slow-integration
 ```
 
-- To run tests and see coverage:
+- 运行测试并查看覆盖率：
 
 ```shell
 pytest --cov=autogpt --without-integration --without-slow-integration
 ```
 
-## Running the linter
+## 运行代码检查器
 
-This project uses [flake8](https://flake8.pycqa.org/en/latest/) for linting.
-We currently use the following rules: `E303,W293,W291,W292,E305,E231,E302`.
-See the [flake8 rules](https://www.flake8rules.com/) for more information.
+本项目使用 [flake8](https://flake8.pycqa.org/en/latest/) 进行代码检查。
+我们目前使用以下规则：`E303,W293,W291,W292,E305,E231,E302`。
+更多信息参见 [flake8 规则](https://www.flake8rules.com/)。
 
-To run the linter:
+运行代码检查器：
 
 ```shell
 flake8 .
 ```
 
-Or:
+或者：
 
 ```shell
 python -m flake8 .


### PR DESCRIPTION
## Summary
- translate plugin configuration and gap-handling guide into Simplified Chinese
- localize testing instructions and linter usage for Chinese readers
- provide Chinese guide for enabling and sharing debug logs

## Testing
- `pre-commit run --files docs/plugins.md docs/testing.md docs/share-your-logs.md` *(fails: ModuleNotFoundError: No module named 'openai.error')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai.error')*


------
https://chatgpt.com/codex/tasks/task_e_688f6ad853fc832f9f7bbdd4add71609