### PR TITLE
docs: translate bulletin to Chinese

### DIFF
--- a/BULLETIN.md
+++ b/BULLETIN.md
@@ -1,19 +1,26 @@
 # QUICK LINKS 🔗
+# 快速链接 🔗
 # --------------
-🌎 *Official Website*: https://agpt.co.
-📖 *User Guide*: https://docs.agpt.co.
-👩 *Contributors Wiki*: https://github.com/Significant-Gravitas/Auto-GPT/wiki/Contributing.
+🌎 *Official Website / 官方网站*: https://agpt.co.
+📖 *User Guide / 用户指南*: https://docs.agpt.co.
+👩 *Contributors Wiki / 贡献者 Wiki*: https://github.com/Significant-Gravitas/Auto-GPT/wiki/Contributing.
 
 # v0.4.7 RELEASE HIGHLIGHTS! 🚀
+# v0.4.7 版本亮点 🚀
 # -----------------------------
-This release introduces initial REST API support, powered by e2b's agent 
-protocol SDK (https://github.com/e2b-dev/agent-protocol#sdk). 
+This release introduces initial REST API support, powered by e2b's agent
+protocol SDK (https://github.com/e2b-dev/agent-protocol#sdk).
+本次发布引入了初步的 REST API 支持，由 e2b 的代理协议 SDK 提供动力 (https://github.com/e2b-dev/agent-protocol#sdk)。
 
 It also includes improvements to prompt generation and the initial REST API support.
+它还包括对提示生成的改进以及初步的 REST API 支持。
 
 We've also moved our documentation to Material Theme, at https://docs.agpt.co.
+我们也将文档迁移到了 Material 主题，网址：https://docs.agpt.co。
 
 As usual, we've squashed a few bugs and made some under-the-hood improvements.
+像往常一样，我们修复了一些错误并进行了底层改进。
 
 Take a look at the Release Notes on Github for the full changelog:
+请在 GitHub 上查看发布说明以获得完整的更新日志：
 https://github.com/Significant-Gravitas/Auto-GPT/releases.


### PR DESCRIPTION
## Summary
- localize release bulletin with Chinese translations and bilingual quick links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mlx')*

------
https://chatgpt.com/codex/tasks/task_e_688f75aa8358832f8a7e4c802b85411e