### PR TITLE
docs: translate configuration docs to Chinese

### DIFF
--- a/docs/configuration/imagegen.md
+++ b/docs/configuration/imagegen.md
@@ -1,63 +1,63 @@
-# 🖼 Image Generation configuration
+# 🖼 图像生成配置
 
-| Config variable  | Values                          |                      |
-| ---------------- | ------------------------------- | -------------------- |
-| `IMAGE_PROVIDER` | `dalle` `huggingface` `sdwebui` | **default: `dalle`** |
+| 配置变量  | 可选值                          |                      |
+| --------- | ------------------------------- | -------------------- |
+| `IMAGE_PROVIDER` | `dalle` `huggingface` `sdwebui` | **默认：`dalle`** |
 
 ## DALL-e
 
-In `.env`, make sure `IMAGE_PROVIDER` is commented (or set to `dalle`):
+在 `.env` 中确保 `IMAGE_PROVIDER` 被注释（或设为 `dalle`）：
 
 ```ini
-# IMAGE_PROVIDER=dalle    # this is the default
+# IMAGE_PROVIDER=dalle    # 默认值
 ```
 
-Further optional configuration:
+其他可选配置：
 
-| Config variable  | Values             |                |
-| ---------------- | ------------------ | -------------- |
-| `IMAGE_SIZE`     | `256` `512` `1024` | default: `256` |
+| 配置变量  | 可选值             |                |
+| ---------- | ------------------ | -------------- |
+| `IMAGE_SIZE`     | `256` `512` `1024` | 默认：`256` |
 
 ## Hugging Face
 
-To use text-to-image models from Hugging Face, you need a Hugging Face API token.
-Link to the appropriate settings page: [Hugging Face > Settings > Tokens](https://huggingface.co/settings/tokens)
+要使用 Hugging Face 的文本生图模型，需要一个 Hugging Face API Token。设置页面链接：[Hugging Face > Settings > Tokens](https://huggingface.co/settings/tokens)
 
-Once you have an API token, uncomment and adjust these variables in your `.env`:
+获取 API Token 后，在 `.env` 中取消注释并调整以下变量：
 
 ```ini
 IMAGE_PROVIDER=huggingface
 HUGGINGFACE_API_TOKEN=your-huggingface-api-token
 ```
 
-Further optional configuration:
+其他可选配置：
 
-| Config variable           | Values                 |                                          |
-| ------------------------- | ---------------------- | ---------------------------------------- |
-| `HUGGINGFACE_IMAGE_MODEL` | see [available models] | default: `CompVis/stable-diffusion-v1-4` |
+| 配置变量           | 可选值                 |                                          |
+| ------------------ | ---------------------- | ---------------------------------------- |
+| `HUGGINGFACE_IMAGE_MODEL` | 见[可用模型] | 默认：`CompVis/stable-diffusion-v1-4` |
 
-[available models]: https://huggingface.co/models?pipeline_tag=text-to-image
+[可用模型]: https://huggingface.co/models?pipeline_tag=text-to-image
 
 ## Stable Diffusion WebUI
 
-It is possible to use your own self-hosted Stable Diffusion WebUI with Auto-GPT:
+可以在 Auto-GPT 中使用自建的 Stable Diffusion WebUI：
 
 ```ini
 IMAGE_PROVIDER=sdwebui
 ```
 
 !!! note
-    Make sure you are running WebUI with `--api` enabled.
+    请确保运行 WebUI 时启用了 `--api`。
 
-Further optional configuration:
+其他可选配置：
 
-| Config variable | Values                  |                                  |
-| --------------- | ----------------------- | -------------------------------- |
-| `SD_WEBUI_URL`  | URL to your WebUI       | default: `http://127.0.0.1:7860` |
-| `SD_WEBUI_AUTH` | `{username}:{password}` | *Note: do not copy the braces!*  |
+| 配置变量 | 可选值                  |                                  |
+| -------- | ----------------------- | -------------------------------- |
+| `SD_WEBUI_URL`  | WebUI 的 URL       | 默认：`http://127.0.0.1:7860` |
+| `SD_WEBUI_AUTH` | `{username}:{password}` | *注意：不要复制花括号！*  |
 
 ## Selenium
 
 ```shell
 sudo Xvfb :10 -ac -screen 0 1024x768x24 & DISPLAY=:10 <YOUR_CLIENT>
 ```
+

--- a/docs/configuration/memory.md
+++ b/docs/configuration/memory.md
@@ -1,53 +1,46 @@
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-## Setting Your Cache Type
+## 设置缓存类型
 
-By default, Auto-GPT uses LocalCache (which stores memory in a JSON file).
+默认情况下，Auto-GPT 使用 LocalCache（将记忆存储在 JSON 文件中）。
 
-To switch to a different backend, change the `MEMORY_BACKEND` in `.env`
-to the value that you want:
+若要切换到其他后端，可在 `.env` 中将 `MEMORY_BACKEND` 修改为你想要的值：
 
-* `json_file` uses a local JSON cache file
-* `pinecone` uses the Pinecone.io account you configured in your ENV settings
-* `redis` will use the redis cache that you configured
-* `milvus` will use the milvus cache that you configured
-* `weaviate` will use the weaviate cache that you configured
+* `json_file` 使用本地 JSON 缓存文件
+* `pinecone` 使用在环境变量中配置的 Pinecone.io 账户
+* `redis` 使用你配置的 redis 缓存
+* `milvus` 使用你配置的 milvus 缓存
+* `weaviate` 使用你配置的 weaviate 缓存
 
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-## Memory Backend Setup
+## 记忆后端设置
 
-Links to memory backends
+记忆后端链接：
 
 - [Pinecone](https://www.pinecone.io/)
-- [Milvus](https://milvus.io/) &ndash; [self-hosted](https://milvus.io/docs), or managed with [Zilliz Cloud](https://zilliz.com/)
+- [Milvus](https://milvus.io/) &ndash; [自托管](https://milvus.io/docs)，或使用 [Zilliz Cloud](https://zilliz.com/)
 - [Redis](https://redis.io)
 - [Weaviate](https://weaviate.io)
 
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-### Redis Setup
+### Redis 设置
 
 !!! caution
-    This setup is not intended to be publicly accessible and lacks security measures.
-    Avoid exposing Redis to the internet without a password or at all!
+    此设置不应公开访问，缺少安全措施。
+    请避免在没有密码的情况下将 Redis 暴露在互联网，或完全避免暴露！
 
-1. Start a Redis server and ensure it listens on port 6379.
-   You can use a local installation from [redis.io](https://redis.io) or any hosted service.
+1. 启动 Redis 服务器并确保其监听 6379 端口。
+   你可以使用 [redis.io](https://redis.io) 的本地安装或任何托管服务。
 
-3. Set the following settings in `.env`
+3. 在 `.env` 中设置以下变量：
 
     ```shell
     MEMORY_BACKEND=redis
@@ -55,140 +48,114 @@ Links to memory backends
     REDIS_PORT=6379
     REDIS_PASSWORD=<PASSWORD>
     ```
-    
-    Replace `<PASSWORD>` by your password, omitting the angled brackets (<>).
 
-    Optional configuration:
+    将 `<PASSWORD>` 替换为你的密码，省略尖括号。
 
-    - `WIPE_REDIS_ON_START=False` to persist memory stored in Redis between runs.
-    - `MEMORY_INDEX=<WHATEVER>` to specify a name for the memory index in Redis.
-        The default is `auto-gpt`.
+    可选配置：
 
-
+    - `WIPE_REDIS_ON_START=False` 在运行之间保留存储在 Redis 中的记忆。
+    - `MEMORY_INDEX=<WHATEVER>` 指定在 Redis 中使用的记忆索引名称，默认值为 `auto-gpt`。
 
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-### 🌲 Pinecone API Key Setup
+### 🌲 Pinecone API Key 设置
 
-Pinecone lets you store vast amounts of vector-based memory, allowing the agent to load only relevant memories at any given time.
+Pinecone 允许存储大量向量化记忆，使代理在任何时候只需加载相关记忆。
 
-1. Go to [pinecone](https://app.pinecone.io/) and make an account if you don't already have one.
-2. Choose the `Starter` plan to avoid being charged.
-3. Find your API key and region under the default project in the left sidebar.
+1. 前往 [pinecone](https://app.pinecone.io/) 并注册账号（如尚未注册）。
+2. 选择 *Starter* 套餐以避免收费。
+3. 在左侧边栏的默认项目下找到你的 API Key 和区域。
 
-In the `.env` file set:
+在 `.env` 文件中设置：
 
 - `PINECONE_API_KEY`
-- `PINECONE_ENV` (example: `us-east4-gcp`)
+- `PINECONE_ENV`（示例：`us-east4-gcp`）
 - `MEMORY_BACKEND=pinecone`
 
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-### Milvus Setup
+### Milvus 设置
 
-[Milvus](https://milvus.io/) is an open-source, highly scalable vector database to store
-huge amounts of vector-based memory and provide fast relevant search. It can be deployed
-locally or used as a cloud service provided by [Zilliz Cloud](https://zilliz.com/).
+[Milvus](https://milvus.io/) 是一个开源、高度可扩展的向量数据库，可存储大量向量化记忆并提供快速的相关搜索。可本地部署或使用 [Zilliz Cloud](https://zilliz.com/) 提供的云服务。
 
-1. Deploy your Milvus service locally or use a managed Zilliz Cloud database:
-    - [Install and deploy Milvus locally](https://milvus.io/docs/install_standalone-operator.md)
+1. 本地部署 Milvus 服务或使用托管的 Zilliz Cloud 数据库：
+    - [本地安装并部署 Milvus](https://milvus.io/docs/install_standalone-operator.md)
 
-    - Set up a managed Zilliz Cloud database
-        1. Go to [Zilliz Cloud](https://zilliz.com/) and sign up if you don't already have account.
-        2. In the *Databases* tab, create a new database.
-            - Remember your username and password
-            - Wait until the database status is changed to RUNNING.
-        3. In the *Database detail* tab of the database you have created, the public cloud endpoint, such as:
-        `https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443`.
+    - 设置托管的 Zilliz Cloud 数据库
+        1. 访问 [Zilliz Cloud](https://zilliz.com/) 并注册账号（如尚未注册）。
+        2. 在 *Databases* 选项卡中创建新数据库。
+            - 记下你的用户名和密码
+            - 等待数据库状态变为 RUNNING
+        3. 在所创建数据库的 *Database detail* 选项卡中可以找到公共云端点，例如：`https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443`。
 
-2. Run `pip3 install pymilvus` to install the required client library.
-    Make sure your PyMilvus version and Milvus version are [compatible](https://github.com/milvus-io/pymilvus#compatibility)
-    to avoid issues.
-    See also the [PyMilvus installation instructions](https://github.com/milvus-io/pymilvus#installation).
+2. 运行 `pip3 install pymilvus` 安装所需客户端库。确保 PyMilvus 版本与你的 Milvus 版本[兼容](https://github.com/milvus-io/pymilvus#compatibility)，以避免问题。参见 [PyMilvus 安装说明](https://github.com/milvus-io/pymilvus#installation)。
 
-3. Update `.env`:
+3. 更新 `.env`：
     - `MEMORY_BACKEND=milvus`
-    - One of:
-        - `MILVUS_ADDR=host:ip` (for local instance)
-        - `MILVUS_ADDR=https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443` (for Zilliz Cloud)
-
-    The following settings are **optional**:
-
+    - 二选一：
+        - `MILVUS_ADDR=host:ip`（本地实例）
+        - `MILVUS_ADDR=https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443`（Zilliz Cloud）
     - `MILVUS_USERNAME='username-of-your-milvus-instance'`
     - `MILVUS_PASSWORD='password-of-your-milvus-instance'`
-    - `MILVUS_SECURE=True` to use a secure connection.
-        Only use if your Milvus instance has TLS enabled.
-        *Note: setting `MILVUS_ADDR` to a `https://` URL will override this setting.*
-    - `MILVUS_COLLECTION` to change the collection name to use in Milvus.
-        Defaults to `autogpt`.
+    - `MILVUS_SECURE=True` 使用安全连接，仅当你的 Milvus 实例启用了 TLS 时使用。
+        *注意：将 `MILVUS_ADDR` 设置为 `https://` URL 会覆盖此设置。*
+    - `MILVUS_COLLECTION` 更改在 Milvus 中使用的集合名称，默认值为 `autogpt`。
 
 !!! warning
-    The Pinecone, Milvus, Redis, and Weaviate memory backends were rendered incompatible
-    by work on the memory system, and have been removed.
-    Whether support will be added back in the future is subject to discussion,
-    feel free to pitch in: https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280
+    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
+    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
-### Weaviate Setup
-[Weaviate](https://weaviate.io/) is an open-source vector database. It allows to store
-data objects and vector embeddings from ML-models and scales seamlessly to billion of
-data objects. To set up a Weaviate database, check out their [Quickstart Tutorial](https://weaviate.io/developers/weaviate/quickstart).
+### Weaviate 设置
 
-Although still experimental, [Embedded Weaviate](https://weaviate.io/developers/weaviate/installation/embedded)
-is supported which allows the Auto-GPT process itself to start a Weaviate instance.
-To enable it, set `USE_WEAVIATE_EMBEDDED` to `True` and make sure you `pip install "weaviate-client>=3.15.4"`.
+[Weaviate](https://weaviate.io/) 是一个开源向量数据库，可存储数据对象和来自机器学习模型的向量嵌入，并能无缝扩展到数十亿个对象。要设置 Weaviate 数据库，请查看其[快速入门教程](https://weaviate.io/developers/weaviate/quickstart)。
 
-#### Install the Weaviate client
+虽然仍处于实验阶段，但支持使用 [嵌入式 Weaviate](https://weaviate.io/developers/weaviate/installation/embedded)，可让 Auto-GPT 进程自行启动一个 Weaviate 实例。要启用它，将 `USE_WEAVIATE_EMBEDDED` 设置为 `True`，并确保执行 `pip install "weaviate-client>=3.15.4"`。
 
-Install the Weaviate client before usage.
+#### 安装 Weaviate 客户端
+
+在使用前安装 Weaviate 客户端。
 
 ```shell
 $ pip install weaviate-client
 ```
 
-#### Setting up environment variables
+#### 设置环境变量
 
-In your `.env` file set the following:
+在 `.env` 文件中设置以下内容：
 
 ```ini
 MEMORY_BACKEND=weaviate
-WEAVIATE_HOST="127.0.0.1" # the IP or domain of the running Weaviate instance
-WEAVIATE_PORT="8080" 
+WEAVIATE_HOST="127.0.0.1" # 运行中 Weaviate 实例的 IP 或域名
+WEAVIATE_PORT="8080"
 WEAVIATE_PROTOCOL="http"
 WEAVIATE_USERNAME="your username"
 WEAVIATE_PASSWORD="your password"
 WEAVIATE_API_KEY="your weaviate API key if you have one"
-WEAVIATE_EMBEDDED_PATH="/home/me/.local/share/weaviate" # this is optional and indicates where the data should be persisted when running an embedded instance
-USE_WEAVIATE_EMBEDDED=False # set to True to run Embedded Weaviate
-MEMORY_INDEX="Autogpt" # name of the index to create for the application
+WEAVIATE_EMBEDDED_PATH="/home/me/.local/share/weaviate" # 可选，运行嵌入式实例时数据持久化的位置
+USE_WEAVIATE_EMBEDDED=False # 设为 True 以运行嵌入式 Weaviate
+MEMORY_INDEX="Autogpt" # 为应用创建的索引名称
 ```
 
-## View Memory Usage
+## 查看记忆使用情况
 
-View memory usage by using the `--debug` flag :)
+使用 `--debug` 标志可查看记忆使用情况 :)
 
-
-## 🧠 Memory pre-seeding
+## 🧠 记忆预置
 
 !!! warning
-    Data ingestion is broken in v0.4.7 and possibly earlier versions. This is a known issue that will be addressed in future releases. Follow these issues for updates.
+    数据摄取在 v0.4.7 及更早版本中存在问题。这是一个已知问题，将在未来版本中解决。请关注以下 Issue 以获取更新。
     [Issue 4435](https://github.com/Significant-Gravitas/Auto-GPT/issues/4435)
     [Issue 4024](https://github.com/Significant-Gravitas/Auto-GPT/issues/4024)
     [Issue 2076](https://github.com/Significant-Gravitas/Auto-GPT/issues/2076)
 
-
-
-Memory pre-seeding allows you to ingest files into memory and pre-seed it before running Auto-GPT.
+记忆预置允许你在运行 Auto-GPT 前将文件导入记忆。
 
 ```shell
-$ python data_ingestion.py -h 
+$ python data_ingestion.py -h
 usage: data_ingestion.py [-h] (--file FILE | --dir DIR) [--init] [--overlap OVERLAP] [--max_length MAX_LENGTH]
 
 Ingest a file or a directory with multiple files into memory. Make sure to set your .env before running this script.
@@ -204,38 +171,24 @@ options:
 # python data_ingestion.py --dir DataFolder --init --overlap 100 --max_length 2000
 ```
 
-In the example above, the script initializes the memory, ingests all files within the `Auto-Gpt/auto_gpt_workspace/DataFolder` directory into memory with an overlap between chunks of 100 and a maximum length of each chunk of 2000.
+上例中，脚本会初始化记忆，将 `Auto-Gpt/auto_gpt_workspace/DataFolder` 目录中的所有文件导入记忆，块之间重叠 100，单个块最大长度 2000。
 
-Note that you can also use the `--file` argument to ingest a single file into memory and that data_ingestion.py will only ingest files within the `/auto_gpt_workspace` directory.
+注意，也可以使用 `--file` 参数将单个文件导入记忆，且 `data_ingestion.py` 只会摄取 `auto_gpt_workspace` 目录内的文件。
 
-The DIR path is relative to the auto_gpt_workspace directory, so `python data_ingestion.py --dir . --init` will ingest everything in `auto_gpt_workspace` directory.
+DIR 路径是相对于 `auto_gpt_workspace` 目录的，因此 `python data_ingestion.py --dir . --init` 将导入 `auto_gpt_workspace` 目录中的所有内容。
 
-You can adjust the `max_length` and `overlap` parameters to fine-tune the way the
-    documents are presented to the AI when it "recall" that memory:
+你可以调整 `max_length` 和 `overlap` 参数，以微调 AI 在“回忆”该记忆时文档呈现方式：
 
-- Adjusting the overlap value allows the AI to access more contextual information
-    from each chunk when recalling information, but will result in more chunks being
-    created and therefore increase memory backend usage and OpenAI API requests.
-- Reducing the `max_length` value will create more chunks, which can save prompt
-    tokens by allowing for more message history in the context, but will also
-    increase the number of chunks.
-- Increasing the `max_length` value will provide the AI with more contextual
-    information from each chunk, reducing the number of chunks created and saving on
-    OpenAI API requests. However, this may also use more prompt tokens and decrease
-    the overall context available to the AI.
+- 调整 overlap 值可以让 AI 在回忆信息时获取更多上下文，但会生成更多块，从而增加记忆后端使用量和 OpenAI API 请求次数。
+- 减小 `max_length` 会生成更多块，可通过允许更多消息历史进入上下文来节省提示词 Token，但也会增加块数量。
+- 增大 `max_length` 能在每个块中提供更多上下文，减少块数量并节省 OpenAI API 请求，但可能使用更多提示词 Token，并降低 AI 可用的总上下文。
 
-Memory pre-seeding is a technique for improving AI accuracy by ingesting relevant data
-into its memory. Chunks of data are split and added to memory, allowing the AI to access
-them quickly and generate more accurate responses. It's useful for large datasets or when
-specific information needs to be accessed quickly. Examples include ingesting API or
-GitHub documentation before running Auto-GPT.
+记忆预置是一种通过预先摄取相关数据来提升 AI 准确度的技术。数据会被拆分成若干块并加入记忆，AI 可以快速访问，从而生成更准确的响应。它适用于大数据集或需要快速访问特定信息的场景，例如在运行 Auto-GPT 之前摄取 API 或 GitHub 文档。
 
 !!! attention
-    If you use Redis for memory, make sure to run Auto-GPT with `WIPE_REDIS_ON_START=False`
+    如果使用 Redis 作为记忆，请确保运行 Auto-GPT 时设置 `WIPE_REDIS_ON_START=False`
 
-    For other memory backends, we currently forcefully wipe the memory when starting
-    Auto-GPT. To ingest data with those memory backends, you can call the
-    `data_ingestion.py` script anytime during an Auto-GPT run.
+    对于其他记忆后端，我们目前在启动 Auto-GPT 时会强制清空记忆。要在这些后端摄取数据，你可以在 Auto-GPT 运行期间随时调用 `data_ingestion.py` 脚本。
 
-Memories will be available to the AI immediately as they are ingested, even if ingested
-while Auto-GPT is running.
+记忆在摄取后会立即对 AI 可用，即使在 Auto-GPT 运行过程中摄取也是如此。
+

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1,56 +1,57 @@
-# Configuration
+# 配置
 
-Configuration is controlled through the `Config` object. You can set configuration variables via the `.env` file. When a workspace is created, Auto-GPT will automatically generate a `.env` file from `.env.template`, an empty `ai_settings.yaml`, and copy `prompt_settings.yaml` if they are missing. You can edit these files to customize the agent.
+配置由 `Config` 对象控制。你可以通过 `.env` 文件设置配置变量。当创建工作空间时，Auto-GPT 会自动从 `.env.template` 生成 `.env` 文件、一个空的 `ai_settings.yaml`，并在缺少时复制 `prompt_settings.yaml`。可通过编辑这些文件来自定义代理。
 
-## Environment Variables
+## 环境变量
 
-- `AI_SETTINGS_FILE`: Location of the AI Settings file relative to the Auto-GPT root directory. Default: ai_settings.yaml
-- `AUDIO_TO_TEXT_PROVIDER`: Audio To Text Provider. Only option currently is `huggingface`. Default: huggingface
-- `AUTHORISE_COMMAND_KEY`: Key response accepted when authorising commands. Default: y
-- `AZURE_CONFIG_FILE`: Location of the Azure Config file relative to the Auto-GPT root directory. Default: azure.yaml
-- `BROWSE_CHUNK_MAX_LENGTH`: When browsing website, define the length of chunks to summarize. Default: 3000
-- `BROWSE_SPACY_LANGUAGE_MODEL`: [spaCy language model](https://spacy.io/usage/models) to use when creating chunks. Default: en_core_web_sm
-- `CHAT_MESSAGES_ENABLED`: Enable chat messages. Optional
-- `DISABLED_COMMAND_CATEGORIES`: Command categories to disable. Command categories are Python module names, e.g. autogpt.commands.execute_code. See the directory `autogpt/commands` in the source for all command modules. Default: None
-- `ELEVENLABS_API_KEY`: ElevenLabs API Key. Optional.
-- `ELEVENLABS_VOICE_ID`: ElevenLabs Voice ID. Optional.
-- `EMBEDDING_MODEL`: LLM Model to use for embedding tasks. Default: text-embedding-ada-002
-- `EXECUTE_LOCAL_COMMANDS`: If shell commands should be executed locally. Default: True
-- `EXIT_KEY`: Exit key accepted to exit. Default: n
-- `FAST_LLM`: LLM Model to use for most tasks. Default: gpt-3.5-turbo
-- `GITHUB_API_KEY`: [Github API Key](https://github.com/settings/tokens). Optional.
-- `GITHUB_USERNAME`: GitHub Username. Optional.
-- `GOOGLE_API_KEY`: Google API key. Optional.
-- `GOOGLE_CUSTOM_SEARCH_ENGINE_ID`: [Google custom search engine ID](https://programmablesearchengine.google.com/controlpanel/all). Optional.
-- `HEADLESS_BROWSER`: Use a headless browser while Auto-GPT uses a web browser. Setting to `False` will allow you to see Auto-GPT operate the browser. Default: True
-- `HUGGINGFACE_API_TOKEN`: HuggingFace API, to be used for both image generation and audio to text. Optional.
-- `HUGGINGFACE_AUDIO_TO_TEXT_MODEL`: HuggingFace audio to text model. Default: CompVis/stable-diffusion-v1-4
-- `HUGGINGFACE_IMAGE_MODEL`: HuggingFace model to use for image generation. Default: CompVis/stable-diffusion-v1-4
-- `IMAGE_PROVIDER`: Image provider. Options are `dalle`, `huggingface`, and `sdwebui`. Default: dalle
-- `IMAGE_SIZE`: Default size of image to generate. Default: 256
-- `MEMORY_BACKEND`: Memory back-end to use. Currently `json_file` is the only supported and enabled backend. Default: json_file
-- `MEMORY_INDEX`: Value used in the Memory backend for scoping, naming, or indexing. Default: auto-gpt
-- `OPENAI_API_KEY`: *REQUIRED*- Your [OpenAI API Key](https://platform.openai.com/account/api-keys).
-- `OPENAI_ORGANIZATION`: Organization ID in OpenAI. Optional.
-- `PLAIN_OUTPUT`: Plain output, which disables the spinner. Default: False
-- `PLUGINS_CONFIG_FILE`: Path of the Plugins Config file relative to the Auto-GPT root directory. Default: plugins_config.yaml
-- `PROMPT_SETTINGS_FILE`: Location of the Prompt Settings file relative to the Auto-GPT root directory. Default: prompt_settings.yaml
-- `REDIS_HOST`: Redis Host. Default: localhost
-- `REDIS_PASSWORD`: Redis Password. Optional. Default:
-- `REDIS_PORT`: Redis Port. Default: 6379
-- `RESTRICT_TO_WORKSPACE`: The restrict file reading and writing to the workspace directory. Default: True
-- `SD_WEBUI_AUTH`: Stable Diffusion Web UI username:password pair. Optional.
-- `SD_WEBUI_URL`: Stable Diffusion Web UI URL. Default: http://localhost:7860
-- `SHELL_ALLOWLIST`: List of shell commands that ARE allowed to be executed by Auto-GPT. Only applies if `SHELL_COMMAND_CONTROL` is set to `allowlist`. Default: None
-- `SHELL_COMMAND_CONTROL`: Whether to use `allowlist` or `denylist` to determine what shell commands can be executed (Default: denylist)
-- `SHELL_DENYLIST`: List of shell commands that ARE NOT allowed to be executed by Auto-GPT. Only applies if `SHELL_COMMAND_CONTROL` is set to `denylist`. Default: sudo,su
-- `SMART_LLM`: LLM Model to use for "smart" tasks. Default: gpt-4
-- `STREAMELEMENTS_VOICE`: StreamElements voice to use. Default: Brian
-- `TEMPERATURE`: Value of temperature given to OpenAI. Value from 0 to 2. Lower is more deterministic, higher is more random. See https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
-- `TEXT_TO_SPEECH_PROVIDER`: Text to Speech Provider. Options are `gtts`, `macos`, `elevenlabs`, and `streamelements`. Default: gtts
-- `USER_AGENT`: User-Agent given when browsing websites. Default: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
-- `USE_AZURE`: Use Azure's LLM Default: False
-- `USE_WEB_BROWSER`: Which web browser to use. Options are `chrome`, `firefox`, `safari` or `edge` Default: chrome
-- `WIPE_REDIS_ON_START`: Wipes data / index on start. Default: True
-- `SELF_DEVELOP`: Enable the background self development loop. Default: False
-- `SELF_DEVELOP_INTERVAL`: Seconds between repository scans when self development is enabled. Default: 300
+- `AI_SETTINGS_FILE`：AI 设置文件在 Auto-GPT 根目录下的相对位置。默认值：ai_settings.yaml
+- `AUDIO_TO_TEXT_PROVIDER`：音频转文本提供方。目前仅支持 `huggingface`。默认值：huggingface
+- `AUTHORISE_COMMAND_KEY`：授权命令时接受的键。默认值：y
+- `AZURE_CONFIG_FILE`：Azure 配置文件在 Auto-GPT 根目录下的相对位置。默认值：azure.yaml
+- `BROWSE_CHUNK_MAX_LENGTH`：浏览网页时，用于摘要的分块长度。默认值：3000
+- `BROWSE_SPACY_LANGUAGE_MODEL`：创建分块时使用的 [spaCy 语言模型](https://spacy.io/usage/models)。默认值：en_core_web_sm
+- `CHAT_MESSAGES_ENABLED`：是否启用聊天消息。可选。
+- `DISABLED_COMMAND_CATEGORIES`：要禁用的命令类别。命令类别是 Python 模块名称，例如 `autogpt.commands.execute_code`。所有命令模块见源代码中的 `autogpt/commands` 目录。默认值：None
+- `ELEVENLABS_API_KEY`：ElevenLabs API 密钥。可选。
+- `ELEVENLABS_VOICE_ID`：ElevenLabs 语音 ID。可选。
+- `EMBEDDING_MODEL`：用于嵌入任务的 LLM 模型。默认值：text-embedding-ada-002
+- `EXECUTE_LOCAL_COMMANDS`：是否在本地执行 Shell 命令。默认值：True
+- `EXIT_KEY`：退出时接受的键。默认值：n
+- `FAST_LLM`：用于大多数任务的 LLM 模型。默认值：gpt-3.5-turbo
+- `GITHUB_API_KEY`：[GitHub API 密钥](https://github.com/settings/tokens)。可选。
+- `GITHUB_USERNAME`：GitHub 用户名。可选。
+- `GOOGLE_API_KEY`：Google API 密钥。可选。
+- `GOOGLE_CUSTOM_SEARCH_ENGINE_ID`：[Google 自定义搜索引擎 ID](https://programmablesearchengine.google.com/controlpanel/all)。可选。
+- `HEADLESS_BROWSER`：在 Auto-GPT 使用浏览器时是否启用无头模式。设置为 `False` 可观察浏览器操作。默认值：True
+- `HUGGINGFACE_API_TOKEN`：HuggingFace API，用于图像生成和音频转文本。可选。
+- `HUGGINGFACE_AUDIO_TO_TEXT_MODEL`：HuggingFace 音频转文本模型。默认值：CompVis/stable-diffusion-v1-4
+- `HUGGINGFACE_IMAGE_MODEL`：用于图像生成的 HuggingFace 模型。默认值：CompVis/stable-diffusion-v1-4
+- `IMAGE_PROVIDER`：图像提供方。可选值：`dalle`、`huggingface`、`sdwebui`。默认值：dalle
+- `IMAGE_SIZE`：生成图像的默认尺寸。默认值：256
+- `MEMORY_BACKEND`：使用的记忆后端。目前仅支持并启用 `json_file`。默认值：json_file
+- `MEMORY_INDEX`：在记忆后端中用于作用域、命名或索引的值。默认值：auto-gpt
+- `OPENAI_API_KEY`：**必填**——你的 [OpenAI API Key](https://platform.openai.com/account/api-keys)。
+- `OPENAI_ORGANIZATION`：OpenAI 组织 ID。可选。
+- `PLAIN_OUTPUT`：纯文本输出，禁用旋转指示器。默认值：False
+- `PLUGINS_CONFIG_FILE`：插件配置文件相对于 Auto-GPT 根目录的路径。默认值：plugins_config.yaml
+- `PROMPT_SETTINGS_FILE`：提示词设置文件相对于 Auto-GPT 根目录的位置。默认值：prompt_settings.yaml
+- `REDIS_HOST`：Redis 主机。默认值：localhost
+- `REDIS_PASSWORD`：Redis 密码。可选。默认值为空
+- `REDIS_PORT`：Redis 端口。默认值：6379
+- `RESTRICT_TO_WORKSPACE`：是否将文件读写限制在工作空间目录内。默认值：True
+- `SD_WEBUI_AUTH`：Stable Diffusion Web UI 的 `username:password`。可选。
+- `SD_WEBUI_URL`：Stable Diffusion Web UI 的 URL。默认值：http://localhost:7860
+- `SHELL_ALLOWLIST`：允许 Auto-GPT 执行的 Shell 命令列表，仅在 `SHELL_COMMAND_CONTROL` 设为 `allowlist` 时生效。默认值：None
+- `SHELL_COMMAND_CONTROL`：决定使用 `allowlist` 还是 `denylist` 来控制可执行的 Shell 命令。默认值：denylist
+- `SHELL_DENYLIST`：不允许 Auto-GPT 执行的 Shell 命令列表，仅在 `SHELL_COMMAND_CONTROL` 设为 `denylist` 时生效。默认值：sudo,su
+- `SMART_LLM`：用于“智能”任务的 LLM 模型。默认值：gpt-4
+- `STREAMELEMENTS_VOICE`：使用的 StreamElements 语音。默认值：Brian
+- `TEMPERATURE`：传递给 OpenAI 的 temperature 值，范围 0-2。值越低越确定，值越高越随机。详见 https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
+- `TEXT_TO_SPEECH_PROVIDER`：文本转语音提供方。可选值：`gtts`、`macos`、`elevenlabs`、`streamelements`。默认值：gtts
+- `USER_AGENT`：浏览网站时使用的 User-Agent。默认值："Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+- `USE_AZURE`：是否使用 Azure 的 LLM。默认值：False
+- `USE_WEB_BROWSER`：使用的网页浏览器，选项有 `chrome`、`firefox`、`safari`、`edge`。默认值：chrome
+- `WIPE_REDIS_ON_START`：启动时是否清空数据/索引。默认值：True
+- `SELF_DEVELOP`：启用后台自我开发循环。默认值：False
+- `SELF_DEVELOP_INTERVAL`：启用自我开发时仓库扫描的间隔秒数。默认值：300
+

--- a/docs/configuration/search.md
+++ b/docs/configuration/search.md
@@ -1,37 +1,33 @@
-## 🔍 Google API Keys Configuration
+## 🔍 Google API 密钥配置
 
 !!! note
-    This section is optional. Use the official Google API if search attempts return
-    error 429. To use the `google_official_search` command, you need to set up your
-    Google API key in your environment variables.
+    本节为可选内容。当搜索多次尝试返回 429 错误时，可使用官方 Google API。要使用 `google_official_search` 命令，你需要在环境变量中设置 Google API 密钥。
 
-Create your project:
+创建项目：
 
-1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
-2. If you don't already have an account, create one and log in
-3. Create a new project by clicking on the *Select a Project* dropdown at the top of the
-    page and clicking *New Project*
-4. Give it a name and click *Create*
-5. Set up a custom search API and add to your .env file:
-    5. Go to the [APIs & Services Dashboard](https://console.cloud.google.com/apis/dashboard)
-    6. Click *Enable APIs and Services*
-    7. Search for *Custom Search API* and click on it
-    8. Click *Enable*
-    9. Go to the [Credentials](https://console.cloud.google.com/apis/credentials) page
-    10. Click *Create Credentials*
-    11. Choose *API Key*
-    12. Copy the API key
-    13. Set it as the `GOOGLE_API_KEY` in your `.env` file
-14. [Enable](https://console.developers.google.com/apis/api/customsearch.googleapis.com)
-    the Custom Search API on your project. (Might need to wait few minutes to propagate.)
-    Set up a custom search engine and add to your .env file:
-    15. Go to the [Custom Search Engine](https://cse.google.com/cse/all) page
-    16. Click *Add*
-    17. Set up your search engine by following the prompts.
-        You can choose to search the entire web or specific sites
-    18. Once you've created your search engine, click on *Control Panel*
-    19. Click *Basics*
-    20. Copy the *Search engine ID*
-    21. Set it as the `CUSTOM_SEARCH_ENGINE_ID` in your `.env` file
+1. 访问 [Google Cloud Console](https://console.cloud.google.com/)。
+2. 如果还没有账号，请注册并登录。
+3. 点击页面顶部的 *Select a Project* 下拉菜单，选择 *New Project* 创建新项目。
+4. 为项目命名并点击 *Create*。
+5. 设置自定义搜索 API 并在 `.env` 中添加：
+    5. 前往 [APIs & Services Dashboard](https://console.cloud.google.com/apis/dashboard)
+    6. 点击 *Enable APIs and Services*
+    7. 搜索 *Custom Search API* 并点击进入
+    8. 点击 *Enable*
+    9. 转到 [Credentials](https://console.cloud.google.com/apis/credentials) 页面
+    10. 点击 *Create Credentials*
+    11. 选择 *API Key*
+    12. 复制生成的 API 密钥
+    13. 在 `.env` 文件中将其设置为 `GOOGLE_API_KEY`
+14. [启用](https://console.developers.google.com/apis/api/customsearch.googleapis.com) 项目中的 Custom Search API（可能需要等待几分钟才能生效）。
+    设置自定义搜索引擎并在 `.env` 中添加：
+    15. 前往 [Custom Search Engine](https://cse.google.com/cse/all) 页面
+    16. 点击 *Add*
+    17. 按提示设置搜索引擎，你可以选择搜索整个网络或特定网站
+    18. 创建完成后，点击 *Control Panel*
+    19. 点击 *Basics*
+    20. 复制 *Search engine ID*
+    21. 在 `.env` 文件中将其设置为 `CUSTOM_SEARCH_ENGINE_ID`
 
-_Remember that your free daily custom search quota allows only up to 100 searches. To increase this limit, you need to assign a billing account to the project to profit from up to 10K daily searches._
+_请记住，免费自定义搜索每日配额仅允许最多 100 次搜索。若想提升限额，需要为项目绑定结算账号，可获得每日最多 1 万次搜索。_
+

--- a/docs/configuration/voice.md
+++ b/docs/configuration/voice.md
@@ -1,31 +1,29 @@
-# Text to Speech
+# 文本转语音
 
-Enter this command to use TTS _(Text-to-Speech)_ for Auto-GPT
+运行以下命令即可为 Auto-GPT 启用 TTS（Text-to-Speech）：
 
 ```shell
 agpt --speak
 ```
 
-Eleven Labs provides voice technologies such as voice design, speech synthesis, and
-premade voices that Auto-GPT can use for speech.
+Eleven Labs 提供语音设计、语音合成以及预设语音等技术，Auto-GPT 可以利用其进行语音输出。
 
-1. Go to [ElevenLabs](https://beta.elevenlabs.io/) and make an account if you don't
-    already have one.
-2. Choose and setup the *Starter* plan.
-3. Click the top right icon and find *Profile* to locate your API Key.
+1. 访问 [ElevenLabs](https://beta.elevenlabs.io/) 并注册账号（如尚未注册）。
+2. 选择并设置 *Starter* 方案。
+3. 点击右上角图标，在 *Profile* 中找到你的 API Key。
 
-In the `.env` file set:
+在 `.env` 文件中设置：
 
 - `ELEVENLABS_API_KEY`
-- `ELEVENLABS_VOICE_1_ID` (example: _"premade/Adam"_)
+- `ELEVENLABS_VOICE_1_ID`（示例：*"premade/Adam"*）
 
-### List of available voices
+### 可用语音列表
 
 !!! note
-    You can use either the name or the voice ID to configure a voice
+    配置语音时可以使用名称或语音 ID
 
-| Name   | Voice ID |
-| ------ | -------- |
+| 名称  | 语音 ID |
+| ----- | -------- |
 | Rachel | `21m00Tcm4TlvDq8ikWAM` |
 | Domi   | `AZnzlk1XvdvUeBnXmlld` |
 | Bella  | `EXAVITQu4vr4xnSDxMaL` |
@@ -35,3 +33,4 @@ In the `.env` file set:
 | Arnold | `VR6AewLTigWG4xSOukaG` |
 | Adam   | `pNInz6obpgDQGcFmaJgB` |
 | Sam    | `yoZ06aMxZJJ28mfd3POQ` |
+


### PR DESCRIPTION
## Summary
- translate configuration guides (environment variables, memory backends, search, voice, image generation) into Chinese

## Testing
- `pre-commit run --files docs/configuration/options.md docs/configuration/search.md docs/configuration/memory.md docs/configuration/voice.md docs/configuration/imagegen.md -v` *(fails: No module named 'docx', 'git', 'openai.error', 'inflection', 'googleapiclient')*

------
https://chatgpt.com/codex/tasks/task_e_688f79242858832f837f75df7cd9a3b8