### PR TITLE
docs: add Chinese translation for self improvement guide

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -5,7 +5,7 @@ Auto-GPT is an autonomous GPT-4 experiment that chains thoughts to accomplish go
 * 🌐 Internet search and information gathering
 * 💾 Memory and workspace file management
 * 🔌 Plugin system with gap detection
-* 🔁 [Self Improvement Loop](self_improvement.md) for automatic self-development
+* 🔁 [Self Improvement Loop](self_improvement.en.md) for automatic self-development
 * 🧬 [AlphaEvolve strategy evolution](evolve_population.md) to iterate on agent behaviors
 
 Please follow the [Installation](/setup/) guide to get started.

--- a/docs/self_improvement.en.md
+++ b/docs/self_improvement.en.md
@@ -1,0 +1,56 @@
+# Self Improvement Loop
+
+The self improvement modules record exceptions, execution times and results in a
+SQLite database located at `improvement.db`. You can enable the logger via
+`install_exception_logger` and wrap costly operations with `Profiler`.
+
+## Self-development mode
+
+`SelfDevelopManager` runs in a background thread and periodically inspects the
+repository for issues. It gathers signals from the plugin TODO queue, event logs
+and performance data, then uses the LLM based patch generator to propose code
+changes. Generated diffs are applied with `PatchAgent` and validated using
+`black`, `ruff`, `mypy` and `pytest -q`. Results are written to the improvement
+database and an event is emitted for monitoring.
+
+Enable this loop by setting the `SELF_DEVELOP` environment variable to `True`.
+The `SELF_DEVELOP_INTERVAL` variable controls how often the repository is
+scanned (in seconds). Defaults are disabled and 300 seconds respectively.
+
+Configuration values can be overlaid dynamically using a JSON file. The overlay
+supports adjusting OpenAI temperature, search depth or toggling plugins at
+runtime.
+
+Example `overlay.json`:
+
+```json
+{
+  "temperature": 0.7,
+  "search_depth": 3,
+  "plugins": ["my-plugin"]
+}
+```
+
+Pass this file to your agent to customize behaviour:
+
+```python
+from pathlib import Path
+from autogpt.config import ConfigBuilder
+
+config = ConfigBuilder.build_config_from_env(Path.cwd())
+config.apply_overlay("overlay.json")
+```
+
+The Critic-Agent generates a Markdown or JSON report summarising errors and
+profiling data. The Patch-Agent can apply unified diffs and runs `black`,
+`ruff` and `mypy` to ensure the patch is valid. It uses the system `patch`
+command when available. If `patch` is missing, it falls back to the
+[`patch-ng`](https://pypi.org/project/patch-ng/) Python library if installed;
+otherwise a clear error explains how to install the required tool.
+
+## Pause after repeated failures
+
+Each patch attempt is stored in the `patch_attempts` table with a `success`
+flag. When three attempts fail in a row `PatchAgent` writes a timestamp file
+named `self_improve.pause` next to the running process and further patch
+application is blocked. Delete this file to resume the self‑improvement loop.

--- a/docs/self_improvement.md
+++ b/docs/self_improvement.md
@@ -1,27 +1,22 @@
-# Self Improvement Loop
+# 自我改进循环
 
-The self improvement modules record exceptions, execution times and results in a
-SQLite database located at `improvement.db`. You can enable the logger via
-`install_exception_logger` and wrap costly operations with `Profiler`.
+自我改进模块会将异常、执行时间和结果记录到位于 `improvement.db` 的 SQLite 数据库中。
+通过 `install_exception_logger` 可启用异常记录器，并使用 `Profiler` 包裹耗时操作。
 
-## Self-development mode
+## 自我开发模式
 
-`SelfDevelopManager` runs in a background thread and periodically inspects the
-repository for issues. It gathers signals from the plugin TODO queue, event logs
-and performance data, then uses the LLM based patch generator to propose code
-changes. Generated diffs are applied with `PatchAgent` and validated using
-`black`, `ruff`, `mypy` and `pytest -q`. Results are written to the improvement
-database and an event is emitted for monitoring.
+`SelfDevelopManager` 在后台线程运行，定期检查仓库中的问题。它会从插件的 TODO 队列、事件日志和性能数据中收集信号，然后利用基于 LLM 的补丁生成器提出代码变更。生成的 diff 由 `PatchAgent` 应用，并通过 `black`、`ruff`、`mypy` 和 `pytest -q` 验证。验证结果会写入改进数据库，并发送事件用于监控。
 
-Enable this loop by setting the `SELF_DEVELOP` environment variable to `True`.
-The `SELF_DEVELOP_INTERVAL` variable controls how often the repository is
-scanned (in seconds). Defaults are disabled and 300 seconds respectively.
+通过设置环境变量 `SELF_DEVELOP=True` 可以启用该循环，`SELF_DEVELOP_INTERVAL` 控制检查仓库的间隔时间（单位：秒），默认值分别为禁用与 300 秒。
 
-Configuration values can be overlaid dynamically using a JSON file. The overlay
-supports adjusting OpenAI temperature, search depth or toggling plugins at
-runtime.
+```bash
+export SELF_DEVELOP=True
+export SELF_DEVELOP_INTERVAL=300  # 可选：每 300 秒扫描一次仓库
+```
 
-Example `overlay.json`:
+可以通过 JSON 文件动态叠加配置。该叠加层允许在运行时调整 OpenAI temperature、搜索深度或切换插件。
+
+示例 `overlay.json`：
 
 ```json
 {
@@ -31,26 +26,24 @@ Example `overlay.json`:
 }
 ```
 
-Pass this file to your agent to customize behaviour:
+将此文件传递给你的代理以自定义行为：
 
 ```python
 from pathlib import Path
 from autogpt.config import ConfigBuilder
 
+# 从当前路径读取环境变量并构建配置
 config = ConfigBuilder.build_config_from_env(Path.cwd())
+# 应用 overlay.json 中的覆盖配置
 config.apply_overlay("overlay.json")
 ```
 
-The Critic-Agent generates a Markdown or JSON report summarising errors and
-profiling data. The Patch-Agent can apply unified diffs and runs `black`,
-`ruff` and `mypy` to ensure the patch is valid. It uses the system `patch`
-command when available. If `patch` is missing, it falls back to the
-[`patch-ng`](https://pypi.org/project/patch-ng/) Python library if installed;
-otherwise a clear error explains how to install the required tool.
+Critic-Agent 会生成 Markdown 或 JSON 报告，总结错误和性能数据。
+Patch-Agent 可以应用 unified diff，并运行 `black`、`ruff` 和 `mypy` 来确保补丁有效。
+当系统中存在 `patch` 命令时优先使用；若缺失则回退到 Python 库 [`patch-ng`](https://pypi.org/project/patch-ng/)，否则会提示如何安装所需工具。
 
-## Pause after repeated failures
+## 多次失败后暂停
 
-Each patch attempt is stored in the `patch_attempts` table with a `success`
-flag. When three attempts fail in a row `PatchAgent` writes a timestamp file
-named `self_improve.pause` next to the running process and further patch
-application is blocked. Delete this file to resume the self‑improvement loop.
+每次补丁尝试都会以 `success` 标志存储在 `patch_attempts` 表中。当连续三次尝试失败时，`PatchAgent` 会在运行进程旁写入名为 `self_improve.pause` 的时间戳文件并阻止进一步应用补丁。删除该文件即可恢复自我改进循环。
+
+[English version](self_improvement.en.md)


### PR DESCRIPTION
## Summary
- translate self-improvement loop guide into Chinese with commented code and environment variable instructions
- keep original content as self_improvement.en.md and update cross-link in index

## Testing
- `pre-commit run --files docs/self_improvement.md docs/self_improvement.en.md docs/index.en.md` *(fails: ImportError: cannot import name 'OpenAI' from 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_688f7c652630832fb824d6dfc8ef2bca