### PR TITLE
docs: add Chinese env template

### DIFF
--- a/.env.template-zh
+++ b/.env.template-zh
@@ -1,0 +1,214 @@
+# 若需了解这些设置的更多说明，请参阅 docs/configuration/options.md 或访问 docs.agpt.co
+
+################################################################################
+### AUTO-GPT - 通用设置
+################################################################################
+
+## OPENAI_API_KEY - OpenAI API 密钥（示例：my-openai-api-key）
+OPENAI_API_KEY=your-openai-api-key
+
+## EXECUTE_LOCAL_COMMANDS - 允许执行本地命令（默认：False）
+# EXECUTE_LOCAL_COMMANDS=False
+
+## RESTRICT_TO_WORKSPACE - 将文件操作限制在工作区 ./auto_gpt_workspace（默认：True）
+# RESTRICT_TO_WORKSPACE=True
+
+## USER_AGENT - 定义 requests 库在浏览网站时使用的 User-Agent（字符串）
+# USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+
+## AI_SETTINGS_FILE - 指定要使用的 AI 设置文件，相对于 Auto-GPT 根目录。（默认：ai_settings.yaml）
+# AI_SETTINGS_FILE=ai_settings.yaml
+
+## PLUGINS_CONFIG_FILE - plugins_config.yaml 文件的路径，相对于 Auto-GPT 根目录。（默认：plugins_config.yaml）
+# PLUGINS_CONFIG_FILE=plugins_config.yaml
+
+## PROMPT_SETTINGS_FILE - 指定要使用的提示设置文件，相对于 Auto-GPT 根目录。（默认：prompt_settings.yaml）
+# PROMPT_SETTINGS_FILE=prompt_settings.yaml
+
+## OPENAI_BASE_URL - OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
+# 以下为示例：
+# OPENAI_BASE_URL=http://localhost:8080/v1
+
+## OPENAI_FUNCTIONS - 启用 OpenAI Functions：https://platform.openai.com/docs/guides/gpt/function-calling
+## 警告：该功能仅支持 OpenAI 最新的模型。在这些模型于 6 月 27 日成为默认模型之前，请在所选模型名称后加上“-0613”后缀。
+# OPENAI_FUNCTIONS=False
+
+## AUTHORISE COMMAND KEY - 命令授权键
+# AUTHORISE_COMMAND_KEY=y
+
+## EXIT_KEY - 退出 AUTO-GPT 的按键
+# EXIT_KEY=n
+
+## PLAIN_OUTPUT - 简洁输出，禁用旋转器（默认：False）
+# PLAIN_OUTPUT=False
+
+## DISABLED_COMMAND_CATEGORIES - 禁用的命令类别列表（默认：None）
+# DISABLED_COMMAND_CATEGORIES=
+
+################################################################################
+### LLM 提供商
+################################################################################
+
+## TEMPERATURE - 设置 OpenAI 的温度（默认：0）
+# TEMPERATURE=0
+
+## OPENAI_ORG_ID - 你的 OpenAI 组织 ID（默认：None）
+# OPENAI_ORG_ID=
+
+## AZURE_OPENAI_ENDPOINT - 你的 Azure OpenAI 终端地址，例如 "https://your-resource-name.openai.azure.com/"
+# AZURE_OPENAI_ENDPOINT=
+
+## AZURE_OPENAI_API_KEY - Azure OpenAI API 密钥
+# AZURE_OPENAI_API_KEY=
+
+## OPENAI_API_VERSION - Azure OpenAI 的 API 版本
+# OPENAI_API_VERSION=
+
+################################################################################
+### LLM 模型
+################################################################################
+
+## SMART_LLM - 高级语言模型（默认：gpt-4）
+# SMART_LLM=gpt-4
+
+## FAST_LLM - 快速语言模型（默认：gpt-3.5-turbo）
+# FAST_LLM=gpt-3.5-turbo
+
+## EMBEDDING_MODEL - 用于生成嵌入的模型
+# EMBEDDING_MODEL=text-embedding-ada-002
+
+################################################################################
+### SHELL 执行
+################################################################################
+
+## SHELL_COMMAND_CONTROL - 使用 "allowlist" 或 "denylist" 来确定可执行的 Shell 命令（默认：denylist）
+# SHELL_COMMAND_CONTROL=denylist
+
+## 仅当 SHELL_COMMAND_CONTROL 设置为 denylist 时：
+## SHELL_DENYLIST - Auto-GPT 不允许执行的 Shell 命令列表（默认：sudo,su）
+# SHELL_DENYLIST=sudo,su
+
+## 仅当 SHELL_COMMAND_CONTROL 设置为 allowlist 时：
+## SHELL_ALLOWLIST - Auto-GPT 允许执行的 Shell 命令列表（默认：None）
+# SHELL_ALLOWLIST=
+
+################################################################################
+### 内存
+################################################################################
+
+### 通用
+
+## MEMORY_BACKEND - 内存后端类型
+# MEMORY_BACKEND=json_file
+
+## MEMORY_INDEX - 用于作用域、命名或索引的内存后端值（默认：auto-gpt）
+# MEMORY_INDEX=auto-gpt
+
+### Redis
+
+## REDIS_HOST - Redis 主机（默认：localhost，docker-compose 使用 "redis"）
+# REDIS_HOST=localhost
+
+## REDIS_PORT - Redis 端口（默认：6379）
+# REDIS_PORT=6379
+
+## REDIS_PASSWORD - Redis 密码（默认：""）
+# REDIS_PASSWORD=
+
+## WIPE_REDIS_ON_START - 启动时清空数据/索引（默认：True）
+# WIPE_REDIS_ON_START=True
+
+################################################################################
+### 图像生成提供商
+################################################################################
+
+### 通用
+
+## IMAGE_PROVIDER - 图像提供商（默认：dalle）
+# IMAGE_PROVIDER=dalle
+
+## IMAGE_SIZE - 图像大小（默认：256）
+# IMAGE_SIZE=256
+
+### Huggingface（IMAGE_PROVIDER=huggingface）
+
+## HUGGINGFACE_IMAGE_MODEL - Huggingface 的文本转图像模型（默认：CompVis/stable-diffusion-v1-4）
+# HUGGINGFACE_IMAGE_MODEL=CompVis/stable-diffusion-v1-4
+
+## HUGGINGFACE_API_TOKEN - HuggingFace API 令牌（默认：None）
+# HUGGINGFACE_API_TOKEN=
+
+### Stable Diffusion（IMAGE_PROVIDER=sdwebui）
+
+## SD_WEBUI_AUTH - Stable Diffusion Web UI 的用户名:密码（默认：None）
+# SD_WEBUI_AUTH=
+
+## SD_WEBUI_URL - Stable Diffusion Web UI API 地址（默认：http://localhost:7860）
+# SD_WEBUI_URL=http://localhost:7860
+
+################################################################################
+### 语音转文本提供商
+################################################################################
+
+## AUDIO_TO_TEXT_PROVIDER - 语音转文本提供商（默认：huggingface）
+# AUDIO_TO_TEXT_PROVIDER=huggingface
+
+## HUGGINGFACE_AUDIO_TO_TEXT_MODEL - HuggingFace 使用的模型（默认：CompVis/stable-diffusion-v1-4）
+# HUGGINGFACE_AUDIO_TO_TEXT_MODEL=CompVis/stable-diffusion-v1-4
+
+################################################################################
+### GITHUB
+################################################################################
+
+## GITHUB_API_KEY - Github API 密钥 / PAT（默认：None）
+# GITHUB_API_KEY=
+
+## GITHUB_USERNAME - Github 用户名（默认：None）
+# GITHUB_USERNAME=
+
+################################################################################
+### 网页浏览
+################################################################################
+
+## HEADLESS_BROWSER - 是否以无头模式运行浏览器（默认：True）
+# HEADLESS_BROWSER=True
+
+## USE_WEB_BROWSER - 设置 Selenium 使用的浏览器驱动（默认：chrome）
+# USE_WEB_BROWSER=chrome
+
+## BROWSE_CHUNK_MAX_LENGTH - 浏览网站时定义摘要块的长度（默认：3000）
+# BROWSE_CHUNK_MAX_LENGTH=3000
+
+## BROWSE_SPACY_LANGUAGE_MODEL - 创建摘要块时使用的 spaCy 语言模型（默认：en_core_web_sm）
+# BROWSE_SPACY_LANGUAGE_MODEL=en_core_web_sm
+
+## GOOGLE_API_KEY - Google API 密钥（默认：None）
+# GOOGLE_API_KEY=
+
+## GOOGLE_CUSTOM_SEARCH_ENGINE_ID - Google 自定义搜索引擎 ID（默认：None）
+# GOOGLE_CUSTOM_SEARCH_ENGINE_ID=
+
+################################################################################
+### 文本转语音提供商
+################################################################################
+
+## TEXT_TO_SPEECH_PROVIDER - 使用的文本转语音提供商（默认：gtts）
+# TEXT_TO_SPEECH_PROVIDER=gtts
+
+### 仅当 TEXT_TO_SPEECH_PROVIDER=streamelements
+## STREAMELEMENTS_VOICE - StreamElements 使用的语音（默认：Brian）
+# STREAMELEMENTS_VOICE=Brian
+
+### 仅当 TEXT_TO_SPEECH_PROVIDER=elevenlabs
+## ELEVENLABS_API_KEY - Eleven Labs API 密钥（默认：None）
+# ELEVENLABS_API_KEY=
+
+## ELEVENLABS_VOICE_ID - Eleven Labs 语音 ID（示例：None）
+# ELEVENLABS_VOICE_ID=
+
+################################################################################
+### 聊天消息
+################################################################################
+
+## CHAT_MESSAGES_ENABLED - 启用聊天消息（默认：False）
+# CHAT_MESSAGES_ENABLED=False

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ pip install -e .[alphaevolve]
 
 ```bash
 cp .env.template .env
+# 或使用中文模板：
+# cp .env.template-zh .env
 ```
 
 编辑 `.env` 并设置 `OPENAI_API_KEY` 及其他所需值。

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1,6 +1,6 @@
 # 配置
 
-配置由 `Config` 对象控制。你可以通过 `.env` 文件设置配置变量。当创建工作空间时，Auto-GPT 会自动从 `.env.template` 生成 `.env` 文件、一个空的 `ai_settings.yaml`，并在缺少时复制 `prompt_settings.yaml`。可通过编辑这些文件来自定义代理。
+配置由 `Config` 对象控制。你可以通过 `.env` 文件设置配置变量。当创建工作空间时，Auto-GPT 会自动从 `.env.template` 生成 `.env` 文件、一个空的 `ai_settings.yaml`，并在缺少时复制 `prompt_settings.yaml`。可通过编辑这些文件来自定义代理。如需中文注释的模板，可手动复制 `.env.template-zh`。
 
 ## 环境变量
 


### PR DESCRIPTION
## Summary
- add `.env.template-zh` with Simplified Chinese comments for configuration
- mention Chinese `.env` template in README and configuration docs

## Testing
- `pre-commit run --files README.md docs/configuration/options.md .env.template-zh` *(fails: No module named 'docx', 'git', 'inflection', 'googleapiclient', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f85035a3c832f938d36f8c7b1cf14