### PR TITLE
feat: use Chinese spaCy model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "click",
     "charset-normalizer>=3.1.0",
     "spacy>=3.0.0,<4.0.0",
-    "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl",
+    "zh-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.7.0/zh_core_web_sm-3.7.0-py3-none-any.whl",
     "prompt_toolkit>=3.0.38",
     "pydantic",
     "inflection",


### PR DESCRIPTION
## Summary
- switch spaCy language model to `zh-core-web-sm`
- point dependency to new download URL and version

## Testing
- `pre-commit run --files pyproject.toml` *(fails: ModuleNotFoundError: No module named 'docx')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'mlx')*

------
https://chatgpt.com/codex/tasks/task_e_688fa7fc83d0832f9cf9ff85c1d06e8b