### PR TITLE
docs: localize contributing and conduct pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ example-plugin:
 [docs/usage]: https://docs.agpt.co/usage/
 [docs/plugins]: https://docs.agpt.co/plugins/
 
+## 🤝 参与贡献
+
+请阅读 [贡献指南](CONTRIBUTING-zh.md) 与 [行为准则](CODE_OF_CONDUCT-zh.md) 了解如何参与本项目。
+
 ## 💖 资助 Auto-GPT 的开发
 
 如果你愿意请我们喝杯咖啡，你的支持将帮助我们承担 Auto-GPT 的开发成本并推动全自动 AI 的边界！

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,1 +1,5 @@
---8<-- "../CODE_OF_CONDUCT.md"
+# 行为准则
+
+--8<-- "../CODE_OF_CONDUCT-zh.md"
+
+[English version](../CODE_OF_CONDUCT.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,5 @@
-# Contributing
+# 贡献指南
 
---8<-- "../CONTRIBUTING.md"
+--8<-- "../CONTRIBUTING-zh.md"
+
+[English version](../CONTRIBUTING.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,40 +2,40 @@ site_name: Auto-GPT
 site_url: https://docs.agpt.co/
 repo_url: https://github.com/Significant-Gravitas/Auto-GPT
 nav:
-  - Home: index.md
-  - Setup: setup.md
-  - Usage: usage.md
-  - Plugins: plugins.md
-  - Configuration:
-      - Options: configuration/options.md
-      - Search: configuration/search.md
-      - Memory: configuration/memory.md
-      - Voice: configuration/voice.md
-      - Image Generation: configuration/imagegen.md
+  - 首页: index.md
+  - 安装: setup.md
+  - 用法: usage.md
+  - 插件: plugins.md
+  - 配置:
+      - 选项: configuration/options.md
+      - 搜索: configuration/search.md
+      - 记忆: configuration/memory.md
+      - 语音: configuration/voice.md
+      - 图像生成: configuration/imagegen.md
 
-  - Help us improve Auto-GPT:
-      - Share your debug logs with us: share-your-logs.md
-      - Contribution guide: contributing.md
-      - Running tests: testing.md
-      - Code of Conduct: code-of-conduct.md
+  - 帮助我们改进 Auto-GPT:
+      - 分享调试日志: share-your-logs.md
+      - 贡献指南: contributing.md
+      - 运行测试: testing.md
+      - 行为准则: code-of-conduct.md
 
-  - Challenges:
-      - Introduction: challenges/introduction.md
-      - List of Challenges:
-          - Memory:
-              - Introduction: challenges/memory/introduction.md
-              - Memory Challenge A: challenges/memory/challenge_a.md
-              - Memory Challenge B: challenges/memory/challenge_b.md
-              - Memory Challenge C: challenges/memory/challenge_c.md
-              - Memory Challenge D: challenges/memory/challenge_d.md
-          - Information retrieval:
-              - Introduction: challenges/information_retrieval/introduction.md
-              - Information Retrieval Challenge A: challenges/information_retrieval/challenge_a.md
-              - Information Retrieval Challenge B: challenges/information_retrieval/challenge_b.md
-  - Submit a Challenge: challenges/submit.md
-  - Beat a Challenge: challenges/beat.md
+  - 挑战:
+      - 简介: challenges/introduction.md
+      - 挑战列表:
+          - 记忆:
+              - 简介: challenges/memory/introduction.md
+              - 记忆挑战 A: challenges/memory/challenge_a.md
+              - 记忆挑战 B: challenges/memory/challenge_b.md
+              - 记忆挑战 C: challenges/memory/challenge_c.md
+              - 记忆挑战 D: challenges/memory/challenge_d.md
+          - 信息检索:
+              - 简介: challenges/information_retrieval/introduction.md
+              - 信息检索挑战 A: challenges/information_retrieval/challenge_a.md
+              - 信息检索挑战 B: challenges/information_retrieval/challenge_b.md
+  - 提交挑战: challenges/submit.md
+  - 解决挑战: challenges/beat.md
 
-  - License: https://github.com/Significant-Gravitas/Auto-GPT/blob/master/LICENSE
+  - 许可证: https://github.com/Significant-Gravitas/Auto-GPT/blob/master/LICENSE
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- default docs to Chinese for contributing and code of conduct
- link Chinese guidelines from README
- translate documentation navigation to Chinese

## Testing
- `pre-commit run --files README.md docs/code-of-conduct.md docs/contributing.md mkdocs.yml` *(failed: ImportError: cannot import name 'OpenAI' from 'openai')*
- `pytest` *(failed: ImportError: cannot import name 'OpenAI' from 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_688fb94ed0bc832fa196b6d521dd121a