### PR TITLE
Ensure remaining-cycle log runs only for finite values

### DIFF
--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -369,11 +369,12 @@ def run_interaction_loop(
             logger.typewriter_log("\n")
             if cycles_remaining != math.inf:
                 # Print authorized commands left value
-            logger.typewriter_log(
-                _("AUTHORISED COMMANDS LEFT: "),
-                Fore.CYAN,
-                f"{cycles_remaining}",
-            )
+                authorized_commands_left = cycles_remaining
+                logger.typewriter_log(
+                    _("AUTHORISED COMMANDS LEFT: "),
+                    Fore.CYAN,
+                    f"{authorized_commands_left}",
+                )
 
         ###################
         # Execute Command #


### PR DESCRIPTION
## Summary
- Indent remaining-cycle logger so it executes only when cycles are finite
- Store `cycles_remaining` locally before logging to ensure valid block content

## Testing
- `python -m autogpt.app.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_688fde40ef08832fa912330e3f24fbd9