### PR TITLE
chore: localize startup logs

### DIFF
--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -549,9 +549,9 @@ def construct_main_ai_config(
         )
     elif all([ai_config.ai_name, ai_config.ai_role, ai_config.ai_goals]):
         logger.typewriter_log(
-            "Welcome back! ",
+            "欢迎回来！",
             Fore.GREEN,
-            f"Would you like me to return to being {ai_config.ai_name}?",
+            f"你希望我继续作为{ai_config.ai_name}吗？",
             speak_text=True,
         )
         should_continue = clean_input(
@@ -581,7 +581,7 @@ Continue ({authorise}/{exit}): """
 
     if config.restrict_to_workspace:
         logger.typewriter_log(
-            "NOTE:All files/directories created by this agent can be found inside its workspace at:",
+            "注意：该代理创建的所有文件/目录都位于其工作区：",
             Fore.YELLOW,
             f"{config.workspace_path}",
         )


### PR DESCRIPTION
## Summary
- localize startup prompt when resuming existing AI configuration
- localize workspace restriction note

## Testing
- `OPENAI_API_KEY=sk-123 python -m autogpt --skip-news` *(fails: AuthenticationError: Incorrect API key provided)*
- `python - <<'PY'
from pathlib import Path
from autogpt.config import ConfigBuilder
from autogpt.app import main as app_main
app_main.clean_input = lambda *args, **kwargs: 'y'
config = ConfigBuilder.build_config_from_env(workdir=Path('.'))
app_main.construct_main_ai_config(config)
PY`
- `pytest tests/unit/test_config.py tests/unit/test_ai_config.py -q` *(fails: openai.AuthenticationError; AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_688fe5a9471c832f91bddbb0da524005