### PR TITLE
feat: localize API cost failure warning

### DIFF
--- a/autogpt/app/zh_CN.json
+++ b/autogpt/app/zh_CN.json
@@ -59,5 +59,6 @@
   "ERROR: ": "错误：",
   "The Agent failed to select an action. Error message: {command_name}": "代理未能选择操作。错误信息：{command_name}",
   "NO ACTION SELECTED: ": "未选择操作：",
-  "The Agent failed to select an action.": "代理未能选择操作。"
+  "The Agent failed to select an action.": "代理未能选择操作。",
+  "Failed to update API costs: {err_type}: {err}": "更新 API 成本失败：{err_type}：{err}"
 }

--- a/autogpt/llm/providers/openai.py
+++ b/autogpt/llm/providers/openai.py
@@ -30,6 +30,7 @@ from autogpt.llm.base import (
     TText,
 )
 from autogpt.logs import logger
+from autogpt.app.i18n import _
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.models.command_parameter import ParameterType
 
@@ -179,7 +180,9 @@ def meter_api(func: Callable):
             )
         except Exception as err:
             logger.warn(
-                f"Failed to update API costs: {err.__class__.__name__}: {err}"
+                _(
+                    "Failed to update API costs: {err_type}: {err}"
+                ).format(err_type=err.__class__.__name__, err=err)
             )
         return response
 


### PR DESCRIPTION
## Summary
- add translation support in OpenAI provider
- localize API cost update warning

## Testing
- `pytest tests/unit/test_retry_provider_openai.py` *(fails: ModuleNotFoundError: No module named 'spacy')*


------
https://chatgpt.com/codex/tasks/task_e_6890071dd714832f88979e3c1fba4e45