### PR TITLE
feat: add Chinese translations for plugin warnings

### DIFF
--- a/autogpt/app/zh_CN.json
+++ b/autogpt/app/zh_CN.json
@@ -59,5 +59,7 @@
   "ERROR: ": "错误：",
   "The Agent failed to select an action. Error message: {command_name}": "代理未能选择操作。错误信息：{command_name}",
   "NO ACTION SELECTED: ": "未选择操作：",
-  "The Agent failed to select an action.": "代理未能选择操作。"
+  "The Agent failed to select an action.": "代理未能选择操作。",
+  "Plugin folder {plugin_module_name} found but not configured. If this is a legitimate plugin, please add it to plugins_config.yaml (key: {plugin_module_name}).": "发现插件文件夹 {plugin_module_name} 但未配置。如果这是合法的插件，请将其添加到 plugins_config.yaml（键：{plugin_module_name}）。",
+  "OpenAI Plugin {plugin_module_name} found but not configured": "发现 OpenAI 插件 {plugin_module_name} 但未配置"
 }

--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from autogpt.config import Config
 
 from autogpt.logs import logger
+from autogpt.app.i18n import _
 from autogpt.models.base_open_ai_plugin import BaseOpenAIPlugin
 from autogpt.models.command_registry import CommandRegistry
 
@@ -338,11 +339,11 @@ def scan_plugins(config: Config, debug: bool = False) -> List[AutoGPTPluginTempl
 
         if not plugins_config.is_enabled(plugin_module_name):
             logger.warn(
-                f"Plugin folder {plugin_module_name} found but not configured. If this is a legitimate plugin, please add it to plugins_config.yaml (key: {plugin_module_name})."
+                _("Plugin folder {plugin_module_name} found but not configured. If this is a legitimate plugin, please add it to plugins_config.yaml (key: {plugin_module_name}).").format(plugin_module_name=plugin_module_name)
             )
             continue
 
-        for _, class_obj in inspect.getmembers(plugin):
+        for member_name, class_obj in inspect.getmembers(plugin):
             if (
                 hasattr(class_obj, "_abc_impl")
                 and AutoGPTPluginTemplate in class_obj.__bases__
@@ -413,7 +414,7 @@ def scan_plugins(config: Config, debug: bool = False) -> List[AutoGPTPluginTempl
             for url, openai_plugin_meta in manifests_specs_clients.items():
                 if not plugins_config.is_enabled(url):
                     logger.warn(
-                        f"OpenAI Plugin {plugin_module_name} found but not configured"
+                        _("OpenAI Plugin {plugin_module_name} found but not configured").format(plugin_module_name=plugin_module_name)
                     )
                     continue
 


### PR DESCRIPTION
## Summary
- translate plugin configuration warnings to Chinese via i18n
- provide zh_CN translations for plugin folder and OpenAI plugin warnings

## Testing
- `pytest tests/unit/test_plugins.py` *(fails: AttributeError: 'NoneType' object has no attribute '_get_document' etc.)*
- `python - <<'PY' ... scan_plugins ... PY`

------
https://chatgpt.com/codex/tasks/task_e_689007036330832f9eea6ee3ca3012fb