### PR TITLE
Localize model access warning

### DIFF
--- a/autogpt/app/configurator.py
+++ b/autogpt/app/configurator.py
@@ -13,6 +13,8 @@ from autogpt.llm.api_manager import ApiManager
 from autogpt.logs import logger
 from autogpt.memory.vector import get_supported_memory_backends
 
+from .i18n import _
+
 
 def create_config(
     config: Config,
@@ -179,9 +181,10 @@ def check_model(
         return model_name
 
     logger.typewriter_log(
-        "WARNING: ",
+        _("WARNING: "),
         Fore.YELLOW,
-        f"You do not have access to {model_name}. Setting {model_type} to "
-        f"gpt-3.5-turbo.",
+        _(
+            "You do not have access to {model_name}. Setting {model_type} to gpt-3.5-turbo."
+        ).format(model_name=model_name, model_type=model_type),
     )
     return "gpt-3.5-turbo"

--- a/autogpt/app/zh_CN.json
+++ b/autogpt/app/zh_CN.json
@@ -59,5 +59,7 @@
   "ERROR: ": "错误：",
   "The Agent failed to select an action. Error message: {command_name}": "代理未能选择操作。错误信息：{command_name}",
   "NO ACTION SELECTED: ": "未选择操作：",
-  "The Agent failed to select an action.": "代理未能选择操作。"
+  "The Agent failed to select an action.": "代理未能选择操作。",
+  "WARNING: ": "警告：",
+  "You do not have access to {model_name}. Setting {model_type} to gpt-3.5-turbo.": "您无权访问 {model_name}。将 {model_type} 设置为 gpt-3.5-turbo。"
 }


### PR DESCRIPTION
## Summary
- Localize LLM access warning in Configurator using translation system and Chinese defaults
- Add Chinese translations for warning prefix and message

## Testing
- `pre-commit run --files autogpt/app/configurator.py autogpt/app/zh_CN.json` *(fails: ImportError during test collection)*
- `pytest tests/unit/test_config.py::test_smart_and_fast_llms_set_to_gpt4 -q` *(fails: openai.AuthenticationError: Incorrect API key)*

------
https://chatgpt.com/codex/tasks/task_e_689006f91134832f99f6f4e04ab582ac