### PR TITLE
Localize model access warning

### DIFF
--- a/autogpt/app/configurator.py
+++ b/autogpt/app/configurator.py
@@ -181,7 +181,6 @@ def check_model(
     logger.typewriter_log(
         "WARNING: ",
         Fore.YELLOW,
-        f"You do not have access to {model_name}. Setting {model_type} to "
-        f"gpt-3.5-turbo.",
+        f"您没有权限使用 {model_name}。将 {model_type} 设置为 gpt-3.5-turbo。",
     )
     return "gpt-3.5-turbo"


### PR DESCRIPTION
## Summary
- localize model access warning in configurator to Chinese

## Testing
- `SKIP=autoflake pre-commit run --files autogpt/app/configurator.py` *(fails: ModuleNotFoundError: No module named 'docx', 'git', 'openai.error', 'inflection', 'googleapiclient')*

------
https://chatgpt.com/codex/tasks/task_e_6890315bfd88832f8386eae0b93386bc