### PR TITLE
Translate API cost warning to Chinese

### DIFF
--- a/autogpt/app/zh_CN.json
+++ b/autogpt/app/zh_CN.json
@@ -61,5 +61,6 @@
   "NO ACTION SELECTED: ": "未选择操作：",
   "The Agent failed to select an action.": "代理未能选择操作。",
   "Plugin folder {plugin_module_name} found but not configured. If this is a legitimate plugin, please add it to plugins_config.yaml (key: {plugin_module_name}).": "发现插件文件夹 {plugin_module_name} 但未配置。如果这是合法的插件，请将其添加到 plugins_config.yaml（键：{plugin_module_name}）。",
-  "OpenAI Plugin {plugin_module_name} found but not configured": "发现 OpenAI 插件 {plugin_module_name} 但未配置"
+  "OpenAI Plugin {plugin_module_name} found but not configured": "发现 OpenAI 插件 {plugin_module_name} 但未配置",
+  "Failed to update API costs: {err_class}: {err}": "更新 API 成本失败：{err_class}: {err}"
 }

--- a/autogpt/llm/providers/openai.py
+++ b/autogpt/llm/providers/openai.py
@@ -4,24 +4,25 @@ import functools
 import time
 from dataclasses import dataclass
 from typing import Callable, List, Optional
-from unittest.mock import patch
 
-import openai
 from openai import (
-    OpenAI,
+    APIError,
+    AsyncAzureOpenAI,
     AsyncOpenAI,
     AzureOpenAI,
-    AsyncAzureOpenAI,
-    APIError,
+    OpenAI,
     RateLimitError,
     Timeout,
 )
+
 try:
     from openai import ServiceUnavailableError
 except ImportError:  # openai>=1 does not expose this error
     from openai import InternalServerError as ServiceUnavailableError
+
 from colorama import Fore, Style
 
+from autogpt.app.i18n import _
 from autogpt.llm.base import (
     ChatModelInfo,
     EmbeddingModelInfo,
@@ -30,8 +31,8 @@ from autogpt.llm.base import (
     TText,
 )
 from autogpt.logs import logger
-from autogpt.models.command_registry import CommandRegistry
 from autogpt.models.command_parameter import ParameterType
+from autogpt.models.command_registry import CommandRegistry
 
 OPEN_AI_CHAT_MODELS = {
     info.name: info
@@ -169,9 +170,7 @@ def meter_api(func: Callable):
         response = func(*args, **kwargs)
         try:
             usage = response.usage
-            logger.debug(
-                f"Reported usage from call to model {response.model}: {usage}"
-            )
+            logger.debug(f"Reported usage from call to model {response.model}: {usage}")
             api_manager.update_cost(
                 usage.prompt_tokens,
                 getattr(usage, "completion_tokens", 0),
@@ -179,7 +178,9 @@ def meter_api(func: Callable):
             )
         except Exception as err:
             logger.warn(
-                f"Failed to update API costs: {err.__class__.__name__}: {err}"
+                _("Failed to update API costs: {err_class}: {err}").format(
+                    err_class=err.__class__.__name__, err=err
+                )
             )
         return response
 
@@ -422,9 +423,7 @@ class OpenAIFunctionSpec:
         """
 
         def param_signature(p_spec: OpenAIFunctionSpec.ParameterSpec) -> str:
-            return (
-                f"// {p_spec.description}\n" if p_spec.description else ""
-            ) + (
+            return (f"// {p_spec.description}\n" if p_spec.description else "") + (
                 f"{p_spec.name}{'' if p_spec.required else '?'}: {p_spec.type.value},"
             )
 


### PR DESCRIPTION
## Summary
- localize API cost update failure warning for Chinese output
- add Chinese translation entry for the new message

## Testing
- `SKIP=mypy,autoflake,pytest-check pre-commit run --files autogpt/llm/providers/openai.py autogpt/app/zh_CN.json`
- `pytest` *(fails: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_689034bd4950832fa5e28b66cb06f87a