### PR TITLE
feat(memory): add chroma vector backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ agpt
 - `-w, --workspace-directory PATH` – 代理工作区目录（默认为工作目录下的 `auto_gpt_workspace`）
 - `--ai-settings FILE` – AI 配置的 YAML 文件路径
 - `--prompt-settings FILE` – 提示设置的 YAML 文件路径
-- `--use-memory BACKEND` – 选择记忆后端，如 `local`、`redis`
+- `--use-memory BACKEND` – 选择记忆后端，如 `json_file`、`chroma`
 - `--speak` – 启用文本转语音
 - `--continuous` – 无需用户确认持续运行
 - `--gpt3only` – 全部使用 GPT‑3.5
@@ -126,7 +126,7 @@ agpt
 示例：
 
 ```bash
-agpt --ai-settings ai_settings.yaml --use-memory redis
+agpt --ai-settings ai_settings.yaml --use-memory chroma
 ```
 
 执行 `agpt --help` 查看完整参数列表。

--- a/autogpt/memory/vector/__init__.py
+++ b/autogpt/memory/vector/__init__.py
@@ -3,12 +3,13 @@ from autogpt.logs import logger
 
 from .memory_item import MemoryItem, MemoryItemRelevance
 from .providers.base import VectorMemoryProvider as VectorMemory
+from .providers.chroma import ChromaMemory
 from .providers.json_file import JSONFileMemory
 from .providers.no_memory import NoMemory
 
 # List of supported memory backends
 # Add a backend to this list if the import attempt is successful
-supported_memory = ["json_file", "no_memory"]
+supported_memory = ["json_file", "no_memory", "chroma"]
 
 # try:
 #     from .providers.redis import RedisMemory
@@ -60,6 +61,9 @@ def get_memory(config: Config) -> VectorMemory:
     match config.memory_backend:
         case "json_file":
             memory = JSONFileMemory(config)
+
+        case "chroma":
+            memory = ChromaMemory(config)
 
         case "pinecone":
             raise NotImplementedError(
@@ -135,7 +139,7 @@ def get_memory(config: Config) -> VectorMemory:
     return memory
 
 
-def get_supported_memory_backends():
+def get_supported_memory_backends() -> list[str]:
     return supported_memory
 
 
@@ -145,6 +149,7 @@ __all__ = [
     "MemoryItemRelevance",
     "JSONFileMemory",
     "NoMemory",
+    "ChromaMemory",
     "VectorMemory",
     # "RedisMemory",
     # "PineconeMemory",

--- a/autogpt/memory/vector/providers/__init__.py
+++ b/autogpt/memory/vector/providers/__init__.py
@@ -1,7 +1,9 @@
+from .chroma import ChromaMemory
 from .json_file import JSONFileMemory
 from .no_memory import NoMemory
 
 __all__ = [
     "JSONFileMemory",
     "NoMemory",
+    "ChromaMemory",
 ]

--- a/autogpt/memory/vector/providers/chroma.py
+++ b/autogpt/memory/vector/providers/chroma.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Iterator, Sequence
+from uuid import uuid4
+
+import chromadb
+
+from autogpt.config import Config
+from autogpt.logs import logger
+
+from .. import MemoryItem, MemoryItemRelevance
+from ..utils import get_embedding
+from .base import VectorMemoryProvider
+
+
+class ChromaMemory(VectorMemoryProvider):
+    """Memory backend powered by ChromaDB."""
+
+    def __init__(self, config: Config) -> None:
+        persist_dir = config.workspace_path / "chroma"
+        self._client = chromadb.PersistentClient(path=str(persist_dir))
+        self._collection = self._client.get_or_create_collection(config.memory_index)
+        self._memories: dict[str, MemoryItem] = {}
+        logger.debug(
+            f"Initialized {self.__class__.__name__} with persist dir {persist_dir}"
+        )
+
+    def __iter__(self) -> Iterator[MemoryItem]:
+        return iter(self._memories.values())
+
+    def __contains__(self, x: MemoryItem) -> bool:
+        return any(m == x for m in self._memories.values())
+
+    def __len__(self) -> int:
+        return len(self._memories)
+
+    def add(self, item: MemoryItem) -> int:
+        memory_id = str(uuid4())
+        self._memories[memory_id] = item
+        embedding = (
+            item.e_summary.tolist()
+            if hasattr(item.e_summary, "tolist")
+            else list(item.e_summary)
+        )
+        self._collection.add(ids=[memory_id], embeddings=[embedding])
+        logger.debug(f"Adding item to memory: {item.dump()}")
+        return len(self._memories)
+
+    def discard(self, item: MemoryItem) -> None:
+        remove_ids = [mid for mid, mem in self._memories.items() if mem == item]
+        if not remove_ids:
+            return
+        self._collection.delete(ids=remove_ids)
+        for mid in remove_ids:
+            self._memories.pop(mid, None)
+
+    def clear(self) -> None:
+        self._collection.delete(ids=list(self._memories.keys()))
+        self._memories.clear()
+
+    def get_relevant(
+        self, query: str, k: int, config: Config
+    ) -> Sequence[MemoryItemRelevance]:
+        if len(self._memories) == 0:
+            return []
+        e_query = get_embedding(query, config)
+        result = self._collection.query(
+            query_embeddings=[e_query],
+            n_results=min(k, len(self._memories)),
+        )
+        ids = result.get("ids", [[]])[0]
+        relevances = [
+            MemoryItemRelevance.of(self._memories[mid], query, e_query)
+            for mid in ids
+            if mid in self._memories
+        ]
+        return relevances

--- a/docs/configuration/memory.md
+++ b/docs/configuration/memory.md
@@ -9,6 +9,7 @@
 若要切换到其他后端，可在 `.env` 中将 `MEMORY_BACKEND` 修改为你想要的值：
 
 * `json_file` 使用本地 JSON 缓存文件
+* `chroma` 使用 [Chroma](https://www.trychroma.com/) 向量数据库
 * `pinecone` 使用在环境变量中配置的 Pinecone.io 账户
 * `redis` 使用你配置的 redis 缓存
 * `milvus` 使用你配置的 milvus 缓存
@@ -22,6 +23,7 @@
 
 记忆后端链接：
 
+- [Chroma](https://www.trychroma.com/)
 - [Pinecone](https://www.pinecone.io/)
 - [Milvus](https://milvus.io/) &ndash; [自托管](https://milvus.io/docs)，或使用 [Zilliz Cloud](https://zilliz.com/)
 - [Redis](https://redis.io)
@@ -30,6 +32,22 @@
 !!! warning
     Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
     是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
+
+### Chroma 设置
+
+1. 安装依赖：
+
+    ```shell
+    pip install chromadb
+    ```
+
+2. 在 `.env` 中设置：
+
+    ```ini
+    MEMORY_BACKEND=chroma
+    ```
+
+   数据默认保存在工作空间下的 `chroma` 目录。
 
 ### Redis 设置
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -28,7 +28,7 @@
 - `HUGGINGFACE_IMAGE_MODEL`：用于图像生成的 HuggingFace 模型。默认值：CompVis/stable-diffusion-v1-4
 - `IMAGE_PROVIDER`：图像提供方。可选值：`dalle`、`huggingface`、`sdwebui`。默认值：dalle
 - `IMAGE_SIZE`：生成图像的默认尺寸。默认值：256
-- `MEMORY_BACKEND`：使用的记忆后端。目前仅支持并启用 `json_file`。默认值：json_file
+- `MEMORY_BACKEND`：使用的记忆后端。目前支持 `json_file` 和 `chroma`。默认值：json_file
 - `MEMORY_INDEX`：在记忆后端中用于作用域、命名或索引的值。默认值：auto-gpt
 - `OPENAI_API_KEY`：**必填**——你的 [OpenAI API Key](https://platform.openai.com/account/api-keys)。
 - `OPENAI_ORGANIZATION`：OpenAI 组织 ID。可选。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "agent-protocol>=0.1.1",
     "fastapi",
     "uvicorn",
+    "chromadb",
 ]
 
 [project.urls]

--- a/tests/integration/memory/test_chroma_memory.py
+++ b/tests/integration/memory/test_chroma_memory.py
@@ -1,0 +1,24 @@
+# sourcery skip: snake-case-functions
+"""Tests for ChromaMemory class"""
+
+from autogpt.config import Config
+from autogpt.memory.vector import MemoryItem
+from autogpt.memory.vector.providers.chroma import ChromaMemory
+
+
+def test_chroma_memory_add_retrieve_clear(
+    config: Config, memory_item: MemoryItem, mock_get_embedding: None
+) -> None:
+    index = ChromaMemory(config)
+    index.add(memory_item)
+    results = index.get_relevant("test content", 1, config)
+    assert results[0].memory_item == memory_item
+    index.clear()
+    assert len(index) == 0
+
+
+def test_chroma_memory_discard(config: Config, memory_item: MemoryItem) -> None:
+    index = ChromaMemory(config)
+    index.add(memory_item)
+    index.discard(memory_item)
+    assert len(index) == 0

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -1,17 +1,20 @@
+from typing import Iterator
+
 import numpy
 import pytest
 from pytest_mock import MockerFixture
 
 import autogpt.memory.vector.memory_item as vector_memory_item
 import autogpt.memory.vector.providers.base as memory_provider_base
+import autogpt.memory.vector.providers.chroma as chroma_provider
 from autogpt.config.config import Config
 from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
-from autogpt.memory.vector import get_memory
+from autogpt.memory.vector import VectorMemory, get_memory
 from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def embedding_dimension(config: Config):
+def embedding_dimension(config: Config) -> int:
     return OPEN_AI_EMBEDDING_MODELS[config.embedding_model].embedding_dimensions
 
 
@@ -21,7 +24,7 @@ def mock_embedding(embedding_dimension: int) -> Embedding:
 
 
 @pytest.fixture
-def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int):
+def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int) -> None:
     mocker.patch.object(
         vector_memory_item,
         "get_embedding",
@@ -32,10 +35,17 @@ def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int):
         "get_embedding",
         return_value=[0.0255] * embedding_dimension,
     )
+    mocker.patch.object(
+        chroma_provider,
+        "get_embedding",
+        return_value=[0.0255] * embedding_dimension,
+    )
 
 
 @pytest.fixture
-def memory_none(agent_test_config: Config, mock_get_embedding):
+def memory_none(
+    agent_test_config: Config, mock_get_embedding: None
+) -> Iterator[VectorMemory]:
     was_memory_backend = agent_test_config.memory_backend
 
     agent_test_config.memory_backend = "no_memory"


### PR DESCRIPTION
## Summary
- add Chroma-based vector memory provider and register as backend
- document Chroma memory setup and add dependency
- cover Chroma provider with integration tests

## Testing
- `pre-commit run --files README.md autogpt/memory/vector/__init__.py autogpt/memory/vector/providers/__init__.py autogpt/memory/vector/providers/chroma.py docs/configuration/memory.md docs/configuration/options.md pyproject.toml tests/integration/memory/test_chroma_memory.py tests/integration/memory/utils.py`
- `pytest tests/integration/memory/test_chroma_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689085b01644832f9973d27f8a4878ea