### PR TITLE
Introduce long-term memory module and retrieval

### DIFF
--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -25,6 +25,7 @@ from autogpt.logs.log_cycle import (
     USER_INPUT_FILE_NAME,
     LogCycleHandler,
 )
+from autogpt.memory.long_term import LongTermMemory
 from autogpt.self_improve import NEED_TOOL, DatabaseManager, PluginTodoQueue, Profiler
 from autogpt.workspace import Workspace
 
@@ -54,8 +55,15 @@ class Agent(BaseAgent):
             cycle_budget=cycle_budget,
         )
 
-        self.memory = memory
-        """VectorMemoryProvider used to manage the agent's context (TODO)"""
+        self.vector_memory = memory
+        self.long_term_memory = LongTermMemory(
+            memory,
+            config,
+            enabled=config.use_long_term_memory,
+            threshold=config.long_term_memory_threshold,
+        )
+        self.memory = self.long_term_memory
+        """Long-term memory manager"""
 
         self.workspace = Workspace(config.workspace_path, config.restrict_to_workspace)
         """Workspace that the agent has access to, e.g. for reading/writing files."""
@@ -196,6 +204,8 @@ class Agent(BaseAgent):
             self.history.add("system", "Unable to execute command", "action_result")
         else:
             self.history.add("system", result, "action_result")
+
+        self.long_term_memory.maybe_transfer(self.history)
 
         if self.event_bus:
             self.event_bus.emit(

--- a/autogpt/agents/base.py
+++ b/autogpt/agents/base.py
@@ -112,9 +112,11 @@ class BaseAgent(metaclass=ABCMeta):
         raw_response = create_chat_completion(
             prompt,
             self.config,
-            functions=get_openai_command_specs(self.command_registry)
-            if self.config.openai_functions
-            else None,
+            functions=(
+                get_openai_command_specs(self.command_registry)
+                if self.config.openai_functions
+                else None
+            ),
         )
         self.cycle_count += 1
 
@@ -179,9 +181,20 @@ class BaseAgent(metaclass=ABCMeta):
         trimmed_history = add_history_upto_token_limit(
             prompt, self.history, self.send_token_limit - reserve_tokens
         )
+        insert_index = history_start_index
         if trimmed_history:
             new_summary_msg, _ = self.history.trim_messages(list(prompt), self.config)
-            prompt.insert(history_start_index, new_summary_msg)
+            prompt.insert(insert_index, new_summary_msg)
+            insert_index += 1
+
+        if hasattr(self, "long_term_memory"):
+            long_term = self.long_term_memory.search(self.history.summary)
+            if long_term:
+                long_term_msg = Message(
+                    "system", "Long-term memory:\n" + "\n".join(long_term)
+                )
+                prompt.insert(insert_index, long_term_msg)
+                insert_index += 1
 
         if append_messages:
             prompt.extend(append_messages)
@@ -271,9 +284,11 @@ class BaseAgent(metaclass=ABCMeta):
         response_format = re.sub(
             r"\n\s+",
             "\n",
-            RESPONSE_FORMAT_WITHOUT_COMMAND
-            if self.config.openai_functions
-            else RESPONSE_FORMAT_WITH_COMMAND,
+            (
+                RESPONSE_FORMAT_WITHOUT_COMMAND
+                if self.config.openai_functions
+                else RESPONSE_FORMAT_WITH_COMMAND
+            ),
         )
 
         use_functions = self.config.openai_functions and self.command_registry.commands
@@ -283,6 +298,7 @@ class BaseAgent(metaclass=ABCMeta):
             f"{response_format}\n"
             "You must respond with a JSON object containing **all** the keys specified in the 'thoughts' type, including 'text', 'reasoning', 'plan', 'criticism', and 'speak'."
         )
+
     def on_before_think(
         self,
         prompt: ChatSequence,

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -92,6 +92,8 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     ##########
     memory_backend: str = "json_file"
     memory_index: str = "auto-gpt-memory"
+    use_long_term_memory: bool = False
+    long_term_memory_threshold: int = 10
     redis_host: str = "localhost"
     redis_port: int = 6379
     redis_password: str = ""
@@ -121,7 +123,9 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     # Web browsing
     selenium_web_browser: str = "chrome"
     selenium_headless: bool = True
-    user_agent: str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+    user_agent: str = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+    )
 
     ###################
     # Plugin Settings #
@@ -309,6 +313,9 @@ class ConfigBuilder(Configurable[Config]):
             "user_agent": os.getenv("USER_AGENT"),
             "memory_backend": os.getenv("MEMORY_BACKEND"),
             "memory_index": os.getenv("MEMORY_INDEX"),
+            "use_long_term_memory": os.getenv("USE_LONG_TERM_MEMORY", "False")
+            == "True",
+            "long_term_memory_threshold": os.getenv("LONG_TERM_MEMORY_THRESHOLD"),
             "redis_host": os.getenv("REDIS_HOST"),
             "redis_password": os.getenv("REDIS_PASSWORD"),
             "wipe_redis_on_start": os.getenv("WIPE_REDIS_ON_START", "True") == "True",
@@ -358,6 +365,10 @@ class ConfigBuilder(Configurable[Config]):
             config_dict["redis_port"] = int(cast(str, os.getenv("REDIS_PORT")))
         with contextlib.suppress(TypeError):
             config_dict["temperature"] = float(cast(str, os.getenv("TEMPERATURE")))
+        with contextlib.suppress(TypeError):
+            config_dict["long_term_memory_threshold"] = int(
+                cast(str, config_dict["long_term_memory_threshold"])
+            )
         with contextlib.suppress(TypeError):
             interval_val = os.getenv("SELF_DEVELOP_INTERVAL")
             if interval_val is not None:

--- a/autogpt/memory/long_term.py
+++ b/autogpt/memory/long_term.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autogpt.config import Config
+from autogpt.memory.message_history import MessageHistory
+from autogpt.memory.vector import MemoryItem, VectorMemory
+
+
+@dataclass
+class LongTermMemory:
+    """Manage long-term vector memories separate from MessageHistory."""
+
+    provider: VectorMemory
+    config: Config
+    enabled: bool = True
+    threshold: int = 10
+
+    def add(self, text: str) -> None:
+        """Add a piece of text to long-term memory."""
+        if not self.enabled:
+            return
+        item = MemoryItem.from_text(text, "agent_history", self.config)
+        self.provider.add(item)
+
+    def search(self, query: str, k: int = 5) -> list[str]:
+        """Search long-term memory for relevant items."""
+        if not self.enabled:
+            return []
+        results = self.provider.get_relevant(query, k, self.config)
+        return [r.memory_item.summary for r in results]
+
+    def maybe_transfer(self, history: MessageHistory) -> None:
+        """Move short-term summary into long-term memory when threshold exceeded."""
+        if not self.enabled:
+            return
+        if len(history) >= self.threshold:
+            self.add(history.summary)
+            history.messages.clear()
+            history.last_trimmed_index = 0
+            history.summary = "I was created"

--- a/docs/configuration/memory.md
+++ b/docs/configuration/memory.md
@@ -158,6 +158,19 @@ USE_WEAVIATE_EMBEDDED=False # 设为 True 以运行嵌入式 Weaviate
 MEMORY_INDEX="Autogpt" # 为应用创建的索引名称
 ```
 
+## 长期记忆
+
+`MessageHistory` 负责短期对话，但你现在可以启用长期向量记忆，将总结后的内容写入长期库并在构建提示时自动检索。
+
+在 `.env` 中添加：
+
+```ini
+USE_LONG_TERM_MEMORY=True
+LONG_TERM_MEMORY_THRESHOLD=10  # 超过多少条消息后转移
+```
+
+当短期记忆中的消息数量超过阈值时，其摘要会被保存到长期记忆中并从短期记忆清除。随后每轮对话都会先读取短期摘要，再在长期记忆中进行语义检索并合并结果。
+
 ## 查看记忆使用情况
 
 使用 `--debug` 标志可查看记忆使用情况 :)

--- a/docs/usage.en.md
+++ b/docs/usage.en.md
@@ -31,8 +31,18 @@ agpt --use-memory  <memory-backend>
 ```
 
 !!! note
-    There are shorthands for some of these flags, for example `-m` for `--use-memory`.  
+    There are shorthands for some of these flags, for example `-m` for `--use-memory`.
     Use `agpt --help` for more information.
+
+### Enable long-term memory
+
+You can enable long-term vector memory via environment variables and set when to transfer
+messages from short-term history:
+
+```shell
+export USE_LONG_TERM_MEMORY=True
+export LONG_TERM_MEMORY_THRESHOLD=10
+```
 
 ### Speak Mode
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,15 @@ agpt --use-memory <记忆后端>
 !!! note
     某些选项有简写，例如 `-m` 对应 `--use-memory`。更多信息请运行 `agpt --help`。
 
+### 启用长期记忆
+
+可在环境变量中开启长期记忆并设置阈值，将较早的消息从短期摘要移入长期向量库：
+
+```shell
+export USE_LONG_TERM_MEMORY=True
+export LONG_TERM_MEMORY_THRESHOLD=10
+```
+
 ### 语音模式
 
 启用 TTS（文本转语音）：


### PR DESCRIPTION
## Summary
- add `LongTermMemory` for vector-based persistent memory
- integrate long-term search with short-term summary in agent loop
- document new config flags and usage examples for long-term memory

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/agents/agent.py autogpt/agents/base.py autogpt/config/config.py autogpt/memory/long_term.py docs/configuration/memory.md docs/usage.md docs/usage.en.md` (fails: mypy errors in config)
- `pytest tests/unit/test_config.py::test_config_builder -q` (fails: ModuleNotFoundError: No module named 'pydantic')

------
https://chatgpt.com/codex/tasks/task_e_689089fa6c24832fb3434ce323b67034