### PR TITLE
feat: detect repeated command loops

### DIFF
--- a/autogpt/agents/__init__.py
+++ b/autogpt/agents/__init__.py
@@ -1,4 +1,11 @@
-from .agent import Agent
+from .agent import Agent, CommandRepetitionError
 from .base import AgentThoughts, BaseAgent, CommandArgs, CommandName
 
-__all__ = ["BaseAgent", "Agent", "CommandName", "CommandArgs", "AgentThoughts"]
+__all__ = [
+    "BaseAgent",
+    "Agent",
+    "CommandName",
+    "CommandArgs",
+    "AgentThoughts",
+    "CommandRepetitionError",
+]

--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 import traceback
+from collections import deque
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -30,6 +31,10 @@ from autogpt.self_improve import NEED_TOOL, DatabaseManager, PluginTodoQueue, Pr
 from autogpt.workspace import Workspace
 
 from .base import AgentThoughts, BaseAgent, CommandArgs, CommandName
+
+
+class CommandRepetitionError(RuntimeError):
+    """Raised when the same command is executed too many times."""
 
 
 class Agent(BaseAgent):
@@ -77,6 +82,9 @@ class Agent(BaseAgent):
         self.plugin_queue = plugin_queue
         self.event_bus = event_bus
         self.db = db
+
+        # Track recently executed commands to detect loops
+        self._recent_commands: deque[tuple[str, float]] = deque()
 
     def construct_base_prompt(self, *args: Any, **kwargs: Any) -> ChatSequence:
         if kwargs.get("prepend_messages") is None:
@@ -140,6 +148,18 @@ class Agent(BaseAgent):
             CURRENT_CONTEXT_FILE_NAME,
         )
         return prompt
+
+    def _record_command(self, signature: str) -> int:
+        """Record a command execution and return the count in the recent window."""
+        now = time.time()
+        self._recent_commands.append((signature, now))
+        # Discard commands outside the repeat window
+        while (
+            self._recent_commands
+            and now - self._recent_commands[0][1] > self.config.repeat_window
+        ):
+            self._recent_commands.popleft()
+        return sum(1 for s, _ in self._recent_commands if s == signature)
 
     def execute(
         self,
@@ -226,6 +246,16 @@ class Agent(BaseAgent):
         user_input: str | None,
     ) -> str:
         """Execute a command and emit an event with the result."""
+        signature = None
+        if command_name is not None:
+            signature = command_name
+            if command_args:
+                signature = f"{command_name}:{json.dumps(command_args, sort_keys=True)}"
+            count = self._record_command(signature)
+            if count > self.config.max_repeated_commands:
+                raise CommandRepetitionError(
+                    f"Command '{command_name}' was repeated {count} times."
+                )
         try:
             if self.db:
                 with Profiler(self.db, "execute"):

--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -11,9 +11,13 @@ from typing import Optional
 
 from colorama import Fore, Style
 
-from .i18n import _
-
-from autogpt.agents import Agent, AgentThoughts, CommandArgs, CommandName
+from autogpt.agents import (
+    Agent,
+    AgentThoughts,
+    CommandArgs,
+    CommandName,
+    CommandRepetitionError,
+)
 from autogpt.app.configurator import create_config
 from autogpt.app.setup import prompt_user
 from autogpt.app.spinner import Spinner
@@ -46,6 +50,8 @@ from autogpt.self_improve import (
 from autogpt.speech import say_text
 from autogpt.workspace import Workspace
 from scripts.install_plugin_deps import install_plugin_dependencies
+
+from .i18n import _
 
 
 def run_auto_gpt(
@@ -286,9 +292,7 @@ def run_interaction_loop(
                 spinner.stop()
 
             logger.typewriter_log(
-                _(
-                    "Interrupt signal received. Stopping continuous command execution."
-                ),
+                _("Interrupt signal received. Stopping continuous command execution."),
                 Fore.RED,
             )
             cycles_remaining = 1
@@ -352,9 +356,7 @@ def run_interaction_loop(
                     # Case 2: The agent used up its cycle budget -> reset
                     cycles_remaining = cycle_budget + 1
                 logger.typewriter_log(
-                    _(
-                        "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-="
-                    ),
+                    _("-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-="),
                     Fore.MAGENTA,
                     "",
                 )
@@ -384,7 +386,11 @@ def run_interaction_loop(
         # and then having the decrement set it to 0, exiting the application.
         if command_name != "human_feedback":
             cycles_remaining -= 1
-        result = agent.execute_step(command_name, command_args, user_input)
+        try:
+            result = agent.execute_step(command_name, command_args, user_input)
+        except CommandRepetitionError as e:
+            result = str(e)
+            cycles_remaining = 1
 
         if result is not None:
             logger.typewriter_log(_("SYSTEM: "), Fore.YELLOW, result)

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -83,6 +83,8 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     # Run loop configuration
     continuous_mode: bool = False
     continuous_limit: int = 0
+    max_repeated_commands: int = 3
+    repeat_window: float = 30.0
     # Self development loop
     self_develop_enabled: bool = False
     self_develop_interval: float = 300.0
@@ -123,9 +125,7 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     # Web browsing
     selenium_web_browser: str = "chrome"
     selenium_headless: bool = True
-    user_agent: str = (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
-    )
+    user_agent: str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
 
     ###################
     # Plugin Settings #

--- a/autogpt/core/runner/cli_web_app/server/api.py
+++ b/autogpt/core/runner/cli_web_app/server/api.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from agent_protocol import StepHandler, StepResult
 from colorama import Fore
 
-from autogpt.agents import Agent
+from autogpt.agents import Agent, CommandRepetitionError
 from autogpt.app.main import UserFeedback
 from autogpt.commands import COMMAND_CATEGORIES
 from autogpt.config import AIConfig, ConfigBuilder
@@ -62,7 +62,11 @@ async def interaction_step(
     result: str | None = None
 
     if command_name is not None:
-        result = agent.execute_step(command_name, command_args, user_input)
+        try:
+            result = agent.execute_step(command_name, command_args, user_input)
+        except CommandRepetitionError as e:
+            logger.typewriter_log("SYSTEM: ", Fore.YELLOW, str(e))
+            return
         if result is None:
             logger.typewriter_log("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
             return

--- a/tests/unit/test_command_loop.py
+++ b/tests/unit/test_command_loop.py
@@ -1,0 +1,36 @@
+import pytest
+
+from autogpt.agents import Agent, CommandRepetitionError
+from autogpt.app.main import UserFeedback, run_interaction_loop
+
+
+def test_execute_step_repeated_command_raises(agent: Agent, mocker):
+    agent.config.max_repeated_commands = 2
+    agent.config.repeat_window = 10
+    mocker.patch.object(agent, "execute", return_value="done")
+
+    agent.execute_step("test", {}, None)
+    agent.execute_step("test", {}, None)
+    with pytest.raises(CommandRepetitionError):
+        agent.execute_step("test", {}, None)
+
+
+def test_run_loop_prompts_user_on_repeated_command(agent: Agent, mocker):
+    agent.config.max_repeated_commands = 2
+    agent.config.repeat_window = 10
+    agent.config.continuous_mode = True
+
+    mocker.patch.object(agent, "think", return_value=("repeat", {}, {}))
+    mock_execute = mocker.patch.object(agent, "execute", return_value="ok")
+
+    mocker.patch("autogpt.app.main.update_user")
+    mock_get_user_feedback = mocker.patch(
+        "autogpt.app.main.get_user_feedback",
+        return_value=(UserFeedback.EXIT, "", None),
+    )
+
+    with pytest.raises(SystemExit):
+        run_interaction_loop(agent)
+
+    assert mock_get_user_feedback.call_count == 1
+    assert mock_execute.call_count == agent.config.max_repeated_commands


### PR DESCRIPTION
## Summary
- track recent commands and raise on excessive repeats
- expose `max_repeated_commands` and `repeat_window` configuration
- interrupt execution loop when repeated actions are detected

## Testing
- `SKIP=mypy,pytest-check,autoflake pre-commit run --files autogpt/agents/agent.py autogpt/agents/__init__.py autogpt/app/main.py autogpt/config/config.py autogpt/core/runner/cli_web_app/server/api.py tests/unit/test_command_loop.py`
- `pytest tests/unit/test_command_loop.py` *(fails: ModuleNotFoundError: No module named 'playsound')*


------
https://chatgpt.com/codex/tasks/task_e_68909168d430832fa3f7f450748b3835