### PR TITLE
Add testing command for running pytest

### DIFF
--- a/autogpt/commands/__init__.py
+++ b/autogpt/commands/__init__.py
@@ -1,6 +1,7 @@
 COMMAND_CATEGORIES = [
     "autogpt.commands.execute_code",
     "autogpt.commands.file_operations",
+    "autogpt.commands.testing",
     "autogpt.commands.web_search",
     "autogpt.commands.web_selenium",
     "autogpt.commands.system",

--- a/autogpt/commands/testing.py
+++ b/autogpt/commands/testing.py
@@ -1,0 +1,45 @@
+"""Commands to run tests"""
+
+COMMAND_CATEGORY = "testing"
+COMMAND_CATEGORY_TITLE = "Testing"
+
+import subprocess
+
+from autogpt.agents.agent import Agent
+from autogpt.command_decorator import command
+
+from .decorators import sanitize_path_arg
+
+
+@command(
+    "run_tests",
+    "Run tests located at a given path using pytest",
+    {
+        "path": {
+            "type": "string",
+            "description": "Path to the tests to run",
+            "required": True,
+        }
+    },
+)
+@sanitize_path_arg("path")
+def run_tests(path: str, agent: Agent) -> str:
+    """Run tests using pytest and return the combined output.
+
+    Args:
+        path: Path to the tests to run.
+        agent: The Agent running the command.
+
+    Returns:
+        stdout and stderr from running pytest, or an error message.
+    """
+    try:
+        result = subprocess.run(
+            ["pytest", path],
+            capture_output=True,
+            text=True,
+            cwd=agent.config.workspace_path,
+        )
+        return result.stdout + result.stderr
+    except Exception as e:
+        return f"Error: {e}"

--- a/tests/unit/test_testing_command.py
+++ b/tests/unit/test_testing_command.py
@@ -1,0 +1,18 @@
+import pytest
+
+from autogpt.agents.agent import Agent
+from autogpt.commands.testing import run_tests
+
+
+def test_run_tests_success(workspace, agent: Agent):
+    test_file = workspace.get_path("sample_test.py")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("def test_example():\n    assert True\n")
+
+    result = run_tests(str(test_file), agent=agent)
+    assert "1 passed" in result
+
+
+def test_run_tests_invalid_path(agent: Agent):
+    with pytest.raises(ValueError, match="outside of workspace"):
+        run_tests("../outside/test_sample.py", agent=agent)


### PR DESCRIPTION
## Summary
- add `testing` command module with `run_tests` to execute pytest suites
- include module in command registry
- test `run_tests` for success and invalid path handling

## Testing
- `pytest tests/unit/test_testing_command.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6890ac903540832f843712228f1a5149