### PR TITLE
feat: add testing file creation command

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,7 @@ Always review plugin code for security before enabling it.
 * [🔧 Self Improvement](docs/self_improvement.md)
 * [🧬 Strategy Evolution](docs/evolve_population.md)
 * [🧰 Git Command Guide](docs/commands/git_operations.md)
+* [🧪 Testing Command Guide](docs/commands/testing.md)
 * Configuration
   * [🔍 Web Search](https://docs.agpt.co/configuration/search/)
   * [🧠 Memory](https://docs.agpt.co/configuration/memory/)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ example-plugin:
 * [🔧 自我改进](docs/self_improvement.md)
 * [🧬 策略演化](docs/evolve_population.md)
 * [🧰 Git 命令指南](docs/commands/git_operations.md)
+* [🧪 测试命令指南](docs/commands/testing.md)
 * 配置
   * [🔍 Web 搜索](https://docs.agpt.co/configuration/search/)
   * [🧠 记忆](https://docs.agpt.co/configuration/memory/)

--- a/autogpt/commands/testing.py
+++ b/autogpt/commands/testing.py
@@ -4,11 +4,13 @@ COMMAND_CATEGORY = "testing"
 COMMAND_CATEGORY_TITLE = "Testing"
 
 import subprocess
+from pathlib import Path
 
 from autogpt.agents.agent import Agent
 from autogpt.command_decorator import command
 
 from .decorators import sanitize_path_arg
+from .file_operations import write_to_file
 
 
 @command(
@@ -43,3 +45,46 @@ def run_tests(path: str, agent: Agent) -> str:
         return result.stdout + result.stderr
     except Exception as e:
         return f"Error: {e}"
+
+
+@command(
+    "create_test_file",
+    "Create a new test file",
+    {
+        "file_path": {
+            "type": "string",
+            "description": "Path where the test file should be created",
+            "required": True,
+        },
+        "content": {
+            "type": "string",
+            "description": "Content of the test file",
+            "required": True,
+        },
+    },
+)
+@sanitize_path_arg("file_path")
+def create_test_file(file_path: str, content: str, agent: Agent) -> str:
+    """Create a new test file inside the tests/ directory.
+
+    Args:
+        file_path: Destination path for the new test file.
+        content: Content to write into the test file.
+        agent: The Agent running the command.
+
+    Returns:
+        A message indicating success or failure.
+    """
+    path = Path(file_path)
+
+    try:
+        relative = path.relative_to(agent.workspace.root)
+    except ValueError:
+        return "Error: file_path is outside of the workspace."
+
+    if not relative.parts or relative.parts[0] != "tests":
+        return "Error: Test files must be created inside the tests/ directory."
+    if not path.name.startswith("test_"):
+        return "Error: Test file name must start with 'test_'."
+
+    return write_to_file(file_path, content, agent)

--- a/docs/commands/testing.md
+++ b/docs/commands/testing.md
@@ -1,0 +1,21 @@
+# Testing Command Guide
+
+Auto-GPT provides commands for creating and running tests during development.
+
+## create_test_file
+
+Create a new test file inside the `tests/` directory. The filename must begin with `test_`.
+
+**Parameters**
+
+- `file_path` (required): Path where the test file will be created. Must reside inside `tests/` and start with `test_`.
+- `content` (required): Text content to write into the new test file.
+
+## run_tests
+
+Execute tests located at a given path using `pytest`.
+
+**Parameters**
+
+- `path` (required): Path to the tests to run.
+

--- a/tests/unit/test_testing_command.py
+++ b/tests/unit/test_testing_command.py
@@ -1,7 +1,7 @@
 import pytest
 
 from autogpt.agents.agent import Agent
-from autogpt.commands.testing import run_tests
+from autogpt.commands.testing import create_test_file, run_tests
 
 
 def test_run_tests_success(workspace, agent: Agent):
@@ -16,3 +16,33 @@ def test_run_tests_success(workspace, agent: Agent):
 def test_run_tests_invalid_path(agent: Agent):
     with pytest.raises(ValueError, match="outside of workspace"):
         run_tests("../outside/test_sample.py", agent=agent)
+
+
+def test_create_test_file_success(workspace, agent: Agent):
+    test_file = workspace.get_path("tests/test_generated.py")
+    content = "def test_example():\n    assert True\n"
+
+    result = create_test_file(str(test_file), content, agent=agent)
+
+    assert result == "File written to successfully."
+    assert test_file.exists()
+    with open(test_file, "r", encoding="utf-8") as f:
+        assert content == f.read()
+
+
+def test_create_test_file_invalid_path(workspace, agent: Agent):
+    test_file = workspace.get_path("test_generated.py")
+
+    result = create_test_file(str(test_file), "content", agent=agent)
+
+    assert result.startswith("Error")
+    assert not test_file.exists()
+
+
+def test_create_test_file_invalid_name(workspace, agent: Agent):
+    test_file = workspace.get_path("tests/generated.py")
+
+    result = create_test_file(str(test_file), "content", agent=agent)
+
+    assert result.startswith("Error")
+    assert not test_file.exists()


### PR DESCRIPTION
## Summary
- add `create_test_file` command for safe test file creation
- document testing commands and link from README
- cover test file creation and path validation with unit tests

## Testing
- `pytest tests/unit/test_testing_command.py -q -W ignore`


------
https://chatgpt.com/codex/tasks/task_e_6890af1585c4832fb068b04c19d93d69