### PR TITLE
docs: clarify testing instructions and include pytest

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -148,6 +148,24 @@ example-plugin:
 See the [official plugin repository](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) and the [plugin template](https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template) for examples.
 Always review plugin code for security before enabling it.
 
+## Testing
+
+Install the test dependencies:
+
+```bash
+pip install -e .[test]
+# or
+pip install pytest
+```
+
+Run tests:
+
+```bash
+agpt run_tests <path>
+# or
+pytest
+```
+
 ## 📖 Documentation
 * [⚙️ Setup][docs/setup]
 * [💻 Usage][docs/usage]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ example-plugin:
 参见 [官方插件仓库](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) 和 [插件模板](https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template) 以获取示例。
 启用前请务必检查插件代码以确保安全。
 
+## 测试
+
+安装测试依赖：
+
+```bash
+pip install -e .[test]
+# 或
+pip install pytest
+```
+
+运行测试：
+
+```bash
+agpt run_tests <path>
+# 或
+pytest
+```
+
 ## 📖 文档
 * [⚙️ 设置][docs/setup]
 * [💻 用法][docs/usage]

--- a/docs/commands/testing.md
+++ b/docs/commands/testing.md
@@ -2,6 +2,26 @@
 
 Auto-GPT provides commands for creating and running tests during development.
 
+## Installation
+
+Install the test dependencies:
+
+```bash
+pip install -e .[test]
+# or
+pip install pytest
+```
+
+## Usage
+
+Run tests with either the built-in command or directly with pytest:
+
+```bash
+agpt run_tests <path>
+# or
+pytest
+```
+
 ## create_test_file
 
 Create a new test file inside the `tests/` directory. The filename must begin with `test_`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "chromadb",
+    "pytest",
 ]
 
 [project.urls]
@@ -88,7 +89,7 @@ dev = [
 ]
 
 test = [
-    "pytest",
+    # pytest is part of core dependencies
     "asynctest",
     "pytest-asyncio",
     "pytest-benchmark",


### PR DESCRIPTION
## Summary
- document installation and usage examples for the testing commands in docs and both READMEs
- add pytest to core dependencies and note it in test extras

## Testing
- `pip install -e .[test]`
- `SKIP=pytest-check pre-commit run --files README.md README.en.md docs/commands/testing.md pyproject.toml`
- `pytest tests/unit/test_testing_command.py`


------
https://chatgpt.com/codex/tasks/task_e_6890c9ce9afc832f957d6da69246e1dd