### PR TITLE
feat: introduce lightweight message queue

### DIFF
--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from autogpt.llm.base import ChatModelResponse, ChatSequence
     from autogpt.memory.vector import VectorMemory
     from autogpt.models.command_registry import CommandRegistry
-    from autogpt.event_bus import EventBus
+    from autogpt.event_bus import MessageQueue
 
 from autogpt.json_utils.utilities import extract_dict_from_response, validate_dict
 from autogpt.llm.api_manager import ApiManager
@@ -49,7 +49,7 @@ class Agent(BaseAgent):
         config: Config,
         cycle_budget: Optional[int] = None,
         plugin_queue: PluginTodoQueue | None = None,
-        event_bus: EventBus | None = None,
+        message_queue: MessageQueue | None = None,
         db: DatabaseManager | None = None,
     ):
         super().__init__(
@@ -80,7 +80,7 @@ class Agent(BaseAgent):
         """LogCycleHandler for structured debug logging."""
 
         self.plugin_queue = plugin_queue
-        self.event_bus = event_bus
+        self.message_queue = message_queue
         self.db = db
 
         # Track recently executed commands to detect loops
@@ -227,14 +227,16 @@ class Agent(BaseAgent):
 
         self.long_term_memory.maybe_transfer(self.history)
 
-        if self.event_bus:
-            self.event_bus.emit(
-                "command_result",
+        if self.message_queue:
+            self.message_queue.publish(
                 {
-                    "command_name": command_name,
-                    "command_args": command_args,
-                    "result": result,
-                },
+                    "type": "command_result",
+                    "payload": {
+                        "command_name": command_name,
+                        "command_args": command_args,
+                        "result": result,
+                    },
+                }
             )
 
         return result

--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -31,7 +31,7 @@ from autogpt.app.utils import (
 from autogpt.commands import COMMAND_CATEGORIES
 from autogpt.config import AIConfig, Config, ConfigBuilder, check_openai_api_key
 from autogpt.config_injector import apply_strategy
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import EventBus, MessageQueue
 from autogpt.llm.api_manager import ApiManager
 from autogpt.logs import logger
 from autogpt.memory.vector import get_memory
@@ -159,9 +159,12 @@ def run_auto_gpt(
 
     # Set up self-improvement infrastructure
     event_bus = EventBus(config.workspace_path / "events.db")
-    db = DatabaseManager(config.workspace_path / "improvement.db", event_bus)
+    message_queue = MessageQueue(event_bus)
+    db = DatabaseManager(config.workspace_path / "improvement.db", message_queue)
     install_exception_logger(db, config.workspace_path / "self_improve.log")
-    plugin_queue = PluginTodoQueue(config.workspace_path / "todo_queue.json", event_bus)
+    plugin_queue = PluginTodoQueue(
+        config.workspace_path / "todo_queue.json", message_queue
+    )
     _patch_agent = PatchAgent(
         db=db, pause_file=config.workspace_path / "self_improve.pause"
     )
@@ -174,7 +177,7 @@ def run_auto_gpt(
             plugin_queue=plugin_queue,
             patch_agent=_patch_agent,
             db=db,
-            event_bus=event_bus,
+            message_queue=message_queue,
             workspace=config.workspace_path,
             interval=config.self_develop_interval,
         )
@@ -223,7 +226,7 @@ def run_auto_gpt(
         ai_config=ai_config,
         config=config,
         plugin_queue=plugin_queue,
-        event_bus=event_bus,
+        message_queue=message_queue,
         db=db,
     )
 

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -57,5 +57,7 @@ class EventBus:
                 "payload": json.loads(payload),
             }
 
+from .message_queue import EventMessage, MessageQueue
 
-__all__ = ["EventBus"]
+
+__all__ = ["EventBus", "MessageQueue", "EventMessage"]

--- a/autogpt/event_bus/message_queue.py
+++ b/autogpt/event_bus/message_queue.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Lightweight publish/subscribe message queue with optional backend."""
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable, TypedDict
+
+try:  # pragma: no cover - optional dependency
+    from pubsub import pub
+    _HAS_PUBSUB = True
+except Exception:  # pragma: no cover - library not available
+    pub = None
+    _HAS_PUBSUB = False
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from . import EventBus
+
+
+class EventMessage(TypedDict, total=False):
+    """Event message structure used by :class:`MessageQueue`."""
+
+    type: str
+    payload: dict | str | None
+
+
+class MessageQueue:
+    """Publish/subscribe queue with graceful fallback."""
+
+    def __init__(self, event_bus: "EventBus" | None = None) -> None:
+        self.event_bus = event_bus
+        self._handlers: DefaultDict[str, list[Callable[[EventMessage], None]]] = (
+            defaultdict(list)
+        )
+
+    # -- Core API -----------------------------------------------------
+    def publish(self, event: EventMessage) -> None:
+        """Publish ``event`` to subscribers and the optional :class:`EventBus`."""
+
+        event_type = event.get("type", "")
+        payload = event.get("payload")
+
+        if _HAS_PUBSUB:
+            pub.sendMessage(event_type, message=event)
+        else:
+            for handler in list(self._handlers.get(event_type, [])):
+                handler(event)
+
+        if self.event_bus:
+            self.event_bus.emit(event_type, payload)
+
+    def subscribe(self, event_type: str, handler: Callable[[EventMessage], None]) -> None:
+        """Subscribe ``handler`` to events of ``event_type``."""
+
+        if _HAS_PUBSUB:
+            pub.subscribe(lambda message=None: handler(message), event_type)
+        else:
+            self._handlers[event_type].append(handler)
+
+    # -- Fallback helpers --------------------------------------------
+    def get_events(self, limit: int | None = None) -> Iterable[dict]:
+        """Retrieve events from the underlying :class:`EventBus`, if any."""
+
+        if not self.event_bus:
+            return []
+        return self.event_bus.get_events(limit)
+
+
+__all__ = ["MessageQueue", "EventMessage"]

--- a/autogpt/self_improve/__init__.py
+++ b/autogpt/self_improve/__init__.py
@@ -1,6 +1,6 @@
 """Self improvement utilities."""
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import MessageQueue
 
 from .critic import CriticAgent
 from .database import DatabaseManager
@@ -21,5 +21,5 @@ __all__ = [
     "start_plugin_queue_processor",
     "SelfDevelopManager",
     "NEED_TOOL",
-    "EventBus",
+    "MessageQueue",
 ]

--- a/autogpt/self_improve/database.py
+++ b/autogpt/self_improve/database.py
@@ -7,15 +7,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Tuple
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import MessageQueue
 
 
 class DatabaseManager:
     """Small wrapper around sqlite3 for storing improvement data."""
 
-    def __init__(self, db_path: Path | str, event_bus: EventBus | None = None) -> None:
+    def __init__(self, db_path: Path | str, message_queue: MessageQueue | None = None) -> None:
         self.db_path = Path(db_path)
-        self.event_bus = event_bus
+        self.message_queue = message_queue
         self.connection = sqlite3.connect(self.db_path)
         self.init_db()
 
@@ -81,10 +81,9 @@ class DatabaseManager:
             (datetime.utcnow().isoformat(), exception, traceback_str),
         )
         self.connection.commit()
-        if self.event_bus:
-            self.event_bus.emit(
-                "error",
-                {"exception": exception, "traceback": traceback_str},
+        if self.message_queue:
+            self.message_queue.publish(
+                {"type": "error", "payload": {"exception": exception, "traceback": traceback_str}}
             )
 
     def log_profile(self, name: str, duration: float) -> None:
@@ -94,10 +93,9 @@ class DatabaseManager:
             (datetime.utcnow().isoformat(), name, duration),
         )
         self.connection.commit()
-        if self.event_bus:
-            self.event_bus.emit(
-                "profile",
-                {"name": name, "duration": duration},
+        if self.message_queue:
+            self.message_queue.publish(
+                {"type": "profile", "payload": {"name": name, "duration": duration}}
             )
 
     def log_execution(self, description: str, result: str) -> None:
@@ -107,10 +105,9 @@ class DatabaseManager:
             (datetime.utcnow().isoformat(), description, result),
         )
         self.connection.commit()
-        if self.event_bus:
-            self.event_bus.emit(
-                "execution",
-                {"description": description, "result": result},
+        if self.message_queue:
+            self.message_queue.publish(
+                {"type": "execution", "payload": {"description": description, "result": result}}
             )
 
     def log_profile_detail(
@@ -122,15 +119,17 @@ class DatabaseManager:
             (datetime.utcnow().isoformat(), name, function, ncalls, cumtime),
         )
         self.connection.commit()
-        if self.event_bus:
-            self.event_bus.emit(
-                "profile_detail",
+        if self.message_queue:
+            self.message_queue.publish(
                 {
-                    "name": name,
-                    "function": function,
-                    "ncalls": ncalls,
-                    "cumtime": cumtime,
-                },
+                    "type": "profile_detail",
+                    "payload": {
+                        "name": name,
+                        "function": function,
+                        "ncalls": ncalls,
+                        "cumtime": cumtime,
+                    },
+                }
             )
 
     def get_errors(self) -> Iterable[Tuple]:
@@ -165,10 +164,9 @@ class DatabaseManager:
             (datetime.utcnow().isoformat(), int(success)),
         )
         self.connection.commit()
-        if self.event_bus:
-            self.event_bus.emit(
-                "patch_attempt",
-                {"success": bool(success)},
+        if self.message_queue:
+            self.message_queue.publish(
+                {"type": "patch_attempt", "payload": {"success": bool(success)}}
             )
 
     def get_last_patch_attempts(self, count: int) -> Iterable[Tuple]:

--- a/autogpt/self_improve/plugin_todo_queue.py
+++ b/autogpt/self_improve/plugin_todo_queue.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import MessageQueue
 
 NEED_TOOL = "NEED_TOOL"
 
@@ -25,11 +25,11 @@ class PluginTodoQueue:
     def __init__(
         self,
         file_path: Path | str,
-        event_bus: EventBus | None = None,
+        message_queue: MessageQueue | None = None,
         max_queue_size: Optional[int] = None,
     ) -> None:
         self.file_path = Path(file_path)
-        self.event_bus = event_bus
+        self.message_queue = message_queue
         self.max_queue_size = max_queue_size
         if not self.file_path.exists():
             self.file_path.write_text(json.dumps({"counters": {}, "queue": []}))
@@ -66,10 +66,12 @@ class PluginTodoQueue:
             if not is_duplicate and has_space:
                 self._queue.append(todo)
                 self._counters[gap] = 0  # reset counter after enqueue
-                if self.event_bus:
-                    self.event_bus.emit(
-                        "plugin_gap",
-                        {"gap": gap, "context": context, "goal": goal},
+                if self.message_queue:
+                    self.message_queue.publish(
+                        {
+                            "type": "plugin_gap",
+                            "payload": {"gap": gap, "context": context, "goal": goal},
+                        }
                     )
             elif is_duplicate:
                 # Already queued, reset counter but don't enqueue another

--- a/autogpt/self_improve/self_develop.py
+++ b/autogpt/self_improve/self_develop.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from threading import Event, Thread
 from typing import List
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import MessageQueue
 
 from .database import DatabaseManager
 from .patcher import PatchAgent
@@ -35,7 +35,7 @@ class SelfDevelopManager:
         plugin_queue: PluginTodoQueue,
         patch_agent: PatchAgent,
         db: DatabaseManager,
-        event_bus: EventBus | None,
+        message_queue: MessageQueue | None,
         workspace: Path,
         interval: float = 300.0,
         coverage_threshold: float = 80.0,
@@ -45,7 +45,7 @@ class SelfDevelopManager:
         self.plugin_queue = plugin_queue
         self.patch_agent = patch_agent
         self.db = db
-        self.event_bus = event_bus
+        self.message_queue = message_queue
         self.workspace = workspace
         self.interval = interval
         self.coverage_threshold = coverage_threshold
@@ -98,8 +98,8 @@ class SelfDevelopManager:
             issues.append(Issue(f"Plugin TODO {todo.gap}", todo.context))
 
         # Event log failures
-        if self.event_bus:
-            events = list(self.event_bus.get_events())
+        if self.message_queue:
+            events = list(self.message_queue.get_events())
             new_events = events[self._events_processed :]
             self._events_processed = len(events)
             for event in new_events:
@@ -167,21 +167,25 @@ class SelfDevelopManager:
             self.patch_agent.verify(files)
             export_prompt_config(self.workspace)
             self.db.log_execution(f"Self develop {issue.description}", "success")
-            if self.event_bus:
-                self.event_bus.emit(
-                    "self_develop",
-                    {"issue": issue.description, "result": "success"},
+            if self.message_queue:
+                self.message_queue.publish(
+                    {
+                        "type": "self_develop",
+                        "payload": {"issue": issue.description, "result": "success"},
+                    }
                 )
         except Exception as err:  # pragma: no cover - error path
             self.db.log_execution(
                 f"Self develop {issue.description}",
                 f"failure: {err}",
             )
-            if self.event_bus:
-                self.event_bus.emit(
-                    "self_develop",
+            if self.message_queue:
+                self.message_queue.publish(
                     {
-                        "issue": issue.description,
-                        "result": f"failure: {err}",
-                    },
+                        "type": "self_develop",
+                        "payload": {
+                            "issue": issue.description,
+                            "result": f"failure: {err}",
+                        },
+                    }
                 )

--- a/tests/self_improve/test_plugin_todo_queue.py
+++ b/tests/self_improve/test_plugin_todo_queue.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import EventBus, MessageQueue
 from autogpt.self_improve import PluginTodoQueue
 
 
 def test_plugin_todo_queue(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
     queue_file = tmp_path / "todo_queue.json"
-    queue = PluginTodoQueue(queue_file, event_bus)
+    queue = PluginTodoQueue(queue_file, message_queue)
 
     gap = "test-gap"
     context = "some context"

--- a/tests/self_improve/test_self_develop.py
+++ b/tests/self_improve/test_self_develop.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import EventBus, MessageQueue
 from autogpt.self_improve import (
     DatabaseManager,
     PatchAgent,
@@ -13,7 +13,8 @@ from autogpt.self_improve import (
 def test_self_develop_processes_plugin_todo(tmp_path: Path, monkeypatch: Any) -> None:
     db = DatabaseManager(tmp_path / "improvement.db")
     event_bus = EventBus(tmp_path / "events.db")
-    plugin_queue = PluginTodoQueue(tmp_path / "todo.json", event_bus)
+    message_queue = MessageQueue(event_bus)
+    plugin_queue = PluginTodoQueue(tmp_path / "todo.json", message_queue)
     patch_agent = PatchAgent(db=db)
 
     file_path = tmp_path / "target.py"
@@ -47,7 +48,7 @@ def test_self_develop_processes_plugin_todo(tmp_path: Path, monkeypatch: Any) ->
         plugin_queue=plugin_queue,
         patch_agent=patch_agent,
         db=db,
-        event_bus=event_bus,
+        message_queue=message_queue,
         workspace=tmp_path,
     )
     mgr.review_repository()


### PR DESCRIPTION
## Summary
- add a lightweight publish/subscribe MessageQueue with optional pypubsub backend and SQLite event log fallback
- wire MessageQueue into application setup, self-improvement utilities, and agents for inter-component communication
- update tests for new message queue integration

## Testing
- `pytest tests/self_improve/test_plugin_todo_queue.py::test_plugin_todo_queue -q`
- `pytest tests/self_improve/test_self_develop.py::test_self_develop_processes_plugin_todo -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ce40f178832fbd6ff00b52ee45f9