### PR TITLE
feat(event_bus): extend event message

### DIFF
--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from autogpt.models.command_registry import CommandRegistry
     from autogpt.event_bus import MessageQueue
 
+from autogpt.event_bus import EventMessage
 from autogpt.json_utils.utilities import extract_dict_from_response, validate_dict
 from autogpt.llm.api_manager import ApiManager
 from autogpt.llm.base import Message
@@ -229,14 +230,15 @@ class Agent(BaseAgent):
 
         if self.message_queue:
             self.message_queue.publish(
-                {
-                    "type": "command_result",
-                    "payload": {
+                EventMessage(
+                    event_type="command_result",
+                    payload={
                         "command_name": command_name,
                         "command_args": command_args,
                         "result": result,
                     },
-                }
+                    source_agent=self.ai_config.ai_name,
+                )
             )
 
         return result

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
+from .message_types import EventMessage
+
 
 class EventBus:
     """Simple event bus storing events in a SQLite table."""
@@ -23,41 +25,48 @@ class EventBus:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
                 event_type TEXT,
-                payload TEXT
+                payload TEXT,
+                source_agent TEXT
             )
             """
         )
         self.connection.commit()
 
-    def emit(self, event_type: str, payload: dict | str | None = None) -> None:
+    def emit(self, event: EventMessage) -> None:
         """Record a new event."""
+        payload = event.payload
         if payload is None:
-            payload = {}
-        if not isinstance(payload, str):
+            payload = json.dumps({})
+        elif not isinstance(payload, str):
             payload = json.dumps(payload)
         cur = self.connection.cursor()
         cur.execute(
-            "INSERT INTO events(timestamp, event_type, payload) VALUES (?, ?, ?)",
-            (datetime.utcnow().isoformat(), event_type, payload),
+            "INSERT INTO events(timestamp, event_type, payload, source_agent) VALUES (?, ?, ?, ?)",
+            (event.timestamp, event.event_type, payload, event.source_agent),
         )
         self.connection.commit()
 
-    def get_events(self, limit: int | None = None) -> Iterable[dict]:
+    def get_events(self, limit: int | None = None) -> Iterable[EventMessage]:
         """Yield events from the bus."""
         cur = self.connection.cursor()
-        query = "SELECT timestamp, event_type, payload FROM events ORDER BY id"
+        query = "SELECT timestamp, event_type, payload, source_agent FROM events ORDER BY id"
         rows = cur.execute(
             query + (" LIMIT ?" if limit is not None else ""),
             [limit] if limit is not None else [],
         )
-        for ts, et, payload in rows:
-            yield {
-                "timestamp": ts,
-                "event_type": et,
-                "payload": json.loads(payload),
-            }
+        for ts, et, payload, source_agent in rows:
+            try:
+                payload_obj = json.loads(payload)
+            except Exception:
+                payload_obj = payload
+            yield EventMessage(
+                event_type=et,
+                payload=payload_obj,
+                source_agent=source_agent,
+                timestamp=ts,
+            )
 
-from .message_queue import EventMessage, MessageQueue
 
+from .message_queue import MessageQueue
 
 __all__ = ["EventBus", "MessageQueue", "EventMessage"]

--- a/autogpt/event_bus/message_queue.py
+++ b/autogpt/event_bus/message_queue.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 """Lightweight publish/subscribe message queue with optional backend."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable, TypedDict
+from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable
 
 try:  # pragma: no cover - optional dependency
     from pubsub import pub
+
     _HAS_PUBSUB = True
 except Exception:  # pragma: no cover - library not available
     pub = None
@@ -15,12 +16,7 @@ except Exception:  # pragma: no cover - library not available
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from . import EventBus
 
-
-class EventMessage(TypedDict, total=False):
-    """Event message structure used by :class:`MessageQueue`."""
-
-    type: str
-    payload: dict | str | None
+from .message_types import EventMessage
 
 
 class MessageQueue:
@@ -28,16 +24,15 @@ class MessageQueue:
 
     def __init__(self, event_bus: "EventBus" | None = None) -> None:
         self.event_bus = event_bus
-        self._handlers: DefaultDict[str, list[Callable[[EventMessage], None]]] = (
-            defaultdict(list)
-        )
+        self._handlers: DefaultDict[
+            str, list[Callable[[EventMessage], None]]
+        ] = defaultdict(list)
 
     # -- Core API -----------------------------------------------------
     def publish(self, event: EventMessage) -> None:
         """Publish ``event`` to subscribers and the optional :class:`EventBus`."""
 
-        event_type = event.get("type", "")
-        payload = event.get("payload")
+        event_type = event.event_type
 
         if _HAS_PUBSUB:
             pub.sendMessage(event_type, message=event)
@@ -46,9 +41,11 @@ class MessageQueue:
                 handler(event)
 
         if self.event_bus:
-            self.event_bus.emit(event_type, payload)
+            self.event_bus.emit(event)
 
-    def subscribe(self, event_type: str, handler: Callable[[EventMessage], None]) -> None:
+    def subscribe(
+        self, event_type: str, handler: Callable[[EventMessage], None]
+    ) -> None:
         """Subscribe ``handler`` to events of ``event_type``."""
 
         if _HAS_PUBSUB:
@@ -57,7 +54,7 @@ class MessageQueue:
             self._handlers[event_type].append(handler)
 
     # -- Fallback helpers --------------------------------------------
-    def get_events(self, limit: int | None = None) -> Iterable[dict]:
+    def get_events(self, limit: int | None = None) -> Iterable[EventMessage]:
         """Retrieve events from the underlying :class:`EventBus`, if any."""
 
         if not self.event_bus:

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class EventMessage:
+    """Event message passed through the event bus and message queue."""
+
+    event_type: str
+    payload: dict[str, Any] | str | None = None
+    source_agent: str | None = None
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())

--- a/autogpt/self_improve/database.py
+++ b/autogpt/self_improve/database.py
@@ -7,13 +7,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Tuple
 
-from autogpt.event_bus import MessageQueue
+from autogpt.event_bus import EventMessage, MessageQueue
 
 
 class DatabaseManager:
     """Small wrapper around sqlite3 for storing improvement data."""
 
-    def __init__(self, db_path: Path | str, message_queue: MessageQueue | None = None) -> None:
+    def __init__(
+        self, db_path: Path | str, message_queue: MessageQueue | None = None
+    ) -> None:
         self.db_path = Path(db_path)
         self.message_queue = message_queue
         self.connection = sqlite3.connect(self.db_path)
@@ -83,7 +85,11 @@ class DatabaseManager:
         self.connection.commit()
         if self.message_queue:
             self.message_queue.publish(
-                {"type": "error", "payload": {"exception": exception, "traceback": traceback_str}}
+                EventMessage(
+                    event_type="error",
+                    payload={"exception": exception, "traceback": traceback_str},
+                    source_agent="database_manager",
+                )
             )
 
     def log_profile(self, name: str, duration: float) -> None:
@@ -95,7 +101,11 @@ class DatabaseManager:
         self.connection.commit()
         if self.message_queue:
             self.message_queue.publish(
-                {"type": "profile", "payload": {"name": name, "duration": duration}}
+                EventMessage(
+                    event_type="profile",
+                    payload={"name": name, "duration": duration},
+                    source_agent="database_manager",
+                )
             )
 
     def log_execution(self, description: str, result: str) -> None:
@@ -107,7 +117,11 @@ class DatabaseManager:
         self.connection.commit()
         if self.message_queue:
             self.message_queue.publish(
-                {"type": "execution", "payload": {"description": description, "result": result}}
+                EventMessage(
+                    event_type="execution",
+                    payload={"description": description, "result": result},
+                    source_agent="database_manager",
+                )
             )
 
     def log_profile_detail(
@@ -121,15 +135,16 @@ class DatabaseManager:
         self.connection.commit()
         if self.message_queue:
             self.message_queue.publish(
-                {
-                    "type": "profile_detail",
-                    "payload": {
+                EventMessage(
+                    event_type="profile_detail",
+                    payload={
                         "name": name,
                         "function": function,
                         "ncalls": ncalls,
                         "cumtime": cumtime,
                     },
-                }
+                    source_agent="database_manager",
+                )
             )
 
     def get_errors(self) -> Iterable[Tuple]:
@@ -166,7 +181,11 @@ class DatabaseManager:
         self.connection.commit()
         if self.message_queue:
             self.message_queue.publish(
-                {"type": "patch_attempt", "payload": {"success": bool(success)}}
+                EventMessage(
+                    event_type="patch_attempt",
+                    payload={"success": bool(success)},
+                    source_agent="database_manager",
+                )
             )
 
     def get_last_patch_attempts(self, count: int) -> Iterable[Tuple]:

--- a/autogpt/self_improve/plugin_todo_queue.py
+++ b/autogpt/self_improve/plugin_todo_queue.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-from autogpt.event_bus import MessageQueue
+from autogpt.event_bus import EventMessage, MessageQueue
 
 NEED_TOOL = "NEED_TOOL"
 
@@ -68,10 +68,11 @@ class PluginTodoQueue:
                 self._counters[gap] = 0  # reset counter after enqueue
                 if self.message_queue:
                     self.message_queue.publish(
-                        {
-                            "type": "plugin_gap",
-                            "payload": {"gap": gap, "context": context, "goal": goal},
-                        }
+                        EventMessage(
+                            event_type="plugin_gap",
+                            payload={"gap": gap, "context": context, "goal": goal},
+                            source_agent="plugin_todo_queue",
+                        )
                     )
             elif is_duplicate:
                 # Already queued, reset counter but don't enqueue another

--- a/autogpt/self_improve/self_develop.py
+++ b/autogpt/self_improve/self_develop.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from threading import Event, Thread
 from typing import List
 
-from autogpt.event_bus import MessageQueue
+from autogpt.event_bus import EventMessage, MessageQueue
 
 from .database import DatabaseManager
 from .patcher import PatchAgent
@@ -103,11 +103,11 @@ class SelfDevelopManager:
             new_events = events[self._events_processed :]
             self._events_processed = len(events)
             for event in new_events:
-                if event["event_type"] in {"error", "lint_failure", "test_failure"}:
+                if event.event_type in {"error", "lint_failure", "test_failure"}:
                     issues.append(
                         Issue(
-                            f"Event {event['event_type']}",
-                            json.dumps(event["payload"]),
+                            f"Event {event.event_type}",
+                            json.dumps(event.payload),
                         )
                     )
 
@@ -169,10 +169,11 @@ class SelfDevelopManager:
             self.db.log_execution(f"Self develop {issue.description}", "success")
             if self.message_queue:
                 self.message_queue.publish(
-                    {
-                        "type": "self_develop",
-                        "payload": {"issue": issue.description, "result": "success"},
-                    }
+                    EventMessage(
+                        event_type="self_develop",
+                        payload={"issue": issue.description, "result": "success"},
+                        source_agent="self_develop",
+                    )
                 )
         except Exception as err:  # pragma: no cover - error path
             self.db.log_execution(
@@ -181,11 +182,12 @@ class SelfDevelopManager:
             )
             if self.message_queue:
                 self.message_queue.publish(
-                    {
-                        "type": "self_develop",
-                        "payload": {
+                    EventMessage(
+                        event_type="self_develop",
+                        payload={
                             "issue": issue.description,
                             "result": f"failure: {err}",
                         },
-                    }
+                        source_agent="self_develop",
+                    )
                 )

--- a/tests/self_improve/test_plugin_todo_queue.py
+++ b/tests/self_improve/test_plugin_todo_queue.py
@@ -29,9 +29,9 @@ def test_plugin_todo_queue(tmp_path: Path) -> None:
     assert todo.context == context
     assert todo.goal == goal
 
-    events = [e for e in event_bus.get_events() if e["event_type"] == "plugin_gap"]
+    events = [e for e in event_bus.get_events() if e.event_type == "plugin_gap"]
     assert len(events) == 1
-    assert events[0]["payload"] == {"gap": gap, "context": context, "goal": goal}
+    assert events[0].payload == {"gap": gap, "context": context, "goal": goal}
 
     # queue persists after reload
     reloaded = PluginTodoQueue(queue_file)

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 
-from autogpt.event_bus import EventBus
+from autogpt.event_bus import EventBus, EventMessage
 
 
 def test_event_bus_emit_and_read(tmp_path: Path) -> None:
     bus = EventBus(tmp_path / "events.db")
-    bus.emit("test", {"foo": "bar"})
+    bus.emit(
+        EventMessage(event_type="test", payload={"foo": "bar"}, source_agent="test")
+    )
     events = list(bus.get_events())
     assert len(events) == 1
-    assert events[0]["event_type"] == "test"
-    assert events[0]["payload"]["foo"] == "bar"
+    assert events[0].event_type == "test"
+    assert isinstance(events[0].payload, dict)
+    assert events[0].payload["foo"] == "bar"
+    assert events[0].source_agent == "test"


### PR DESCRIPTION
## Summary
- introduce dataclass EventMessage capturing event_type, payload, source_agent and timestamp
- persist and transport full EventMessage through SQLite-backed EventBus and MessageQueue
- update agents and self-improvement components to publish new EventMessage objects

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/event_bus/message_types.py autogpt/event_bus/__init__.py autogpt/event_bus/message_queue.py autogpt/agents/agent.py autogpt/self_improve/database.py autogpt/self_improve/plugin_todo_queue.py autogpt/self_improve/self_develop.py tests/unit/test_event_bus.py tests/self_improve/test_plugin_todo_queue.py`
- `pytest tests/unit/test_event_bus.py tests/self_improve/test_plugin_todo_queue.py tests/self_improve/test_self_develop.py` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_6890d1515744832fa0e319b74ee426b9