### PR TITLE
Add message queue event bus tests

### DIFF
--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -1,16 +1,92 @@
 from pathlib import Path
 
-from autogpt.event_bus import EventBus, EventMessage
+import pytest
+
+from autogpt.event_bus import EventBus, EventMessage, MessageQueue
 
 
-def test_event_bus_emit_and_read(tmp_path: Path) -> None:
-    bus = EventBus(tmp_path / "events.db")
-    bus.emit(
+@pytest.fixture
+def event_bus(tmp_path: Path) -> EventBus:
+    """Event bus backed by a temporary SQLite database."""
+    return EventBus(tmp_path / "events.db")
+
+
+@pytest.fixture
+def message_queue(event_bus: EventBus, monkeypatch: pytest.MonkeyPatch) -> MessageQueue:
+    """Message queue using the fallback implementation without external backend."""
+
+    # Ensure tests do not depend on the optional `pubsub` package
+    monkeypatch.setattr("autogpt.event_bus.message_queue._HAS_PUBSUB", False)
+    return MessageQueue(event_bus)
+
+
+def test_event_bus_emit_and_read(event_bus: EventBus) -> None:
+    event_bus.emit(
         EventMessage(event_type="test", payload={"foo": "bar"}, source_agent="test")
     )
-    events = list(bus.get_events())
+    events = list(event_bus.get_events())
     assert len(events) == 1
     assert events[0].event_type == "test"
     assert isinstance(events[0].payload, dict)
     assert events[0].payload["foo"] == "bar"
     assert events[0].source_agent == "test"
+
+
+def test_message_queue_publish_from_multiple_sources(
+    message_queue: MessageQueue,
+) -> None:
+    received: list[EventMessage] = []
+
+    message_queue.subscribe("test_event", lambda msg: received.append(msg))
+
+    message_queue.publish(
+        EventMessage(
+            event_type="test_event",
+            payload={"value": 1},
+            source_agent="agent-1",
+        )
+    )
+    message_queue.publish(
+        EventMessage(
+            event_type="test_event",
+            payload={"value": 2},
+            source_agent="agent-2",
+        )
+    )
+
+    assert len(received) == 2
+    assert {e.source_agent for e in received} == {"agent-1", "agent-2"}
+
+    events = list(message_queue.get_events())
+    assert len(events) == 2
+
+
+def test_message_queue_backend_failure(
+    message_queue: MessageQueue, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    received: list[EventMessage] = []
+    message_queue.subscribe("boom", lambda msg: received.append(msg))
+
+    def failing_emit(event: EventMessage) -> None:
+        raise RuntimeError("backend failure")
+
+    monkeypatch.setattr(message_queue.event_bus, "emit", failing_emit)
+
+    with pytest.raises(RuntimeError):
+        message_queue.publish(EventMessage(event_type="boom", payload=None))
+
+    # Subscriber was still notified before the failure
+    assert len(received) == 1
+
+
+def test_event_bus_handles_malformed_payload(event_bus: EventBus) -> None:
+    cur = event_bus.connection.cursor()
+    cur.execute(
+        "INSERT INTO events(timestamp, event_type, payload, source_agent) VALUES (?, ?, ?, ?)",
+        ("ts", "malformed", "{not json", "agent"),
+    )
+    event_bus.connection.commit()
+
+    events = list(event_bus.get_events())
+    assert len(events) == 1
+    assert events[0].payload == "{not json"


### PR DESCRIPTION
## Summary
- add fixtures for event bus and message queue without external backend
- test that subscribers receive events from multiple sources
- test graceful handling of backend failures and malformed payloads

## Testing
- `pytest --confcutdir=tests/unit tests/unit/test_event_bus.py -q`
- `SKIP=autoflake pre-commit run --files tests/unit/test_event_bus.py` *(fails: ModuleNotFoundError: No module named 'git')*

------
https://chatgpt.com/codex/tasks/task_e_6890d4866ad8832fa2c9c1caa3a5e457