### PR TITLE
Add archaeologist diagnostic agent

### DIFF
--- a/autogpt/agents/__init__.py
+++ b/autogpt/agents/__init__.py
@@ -1,4 +1,5 @@
 from .agent import Agent, CommandRepetitionError
+from .archaeologist import DIAGNOSIS_COMPLETE, ISSUE_DETECTED, Archaeologist
 from .base import AgentThoughts, BaseAgent, CommandArgs, CommandName
 
 __all__ = [
@@ -8,4 +9,7 @@ __all__ = [
     "CommandArgs",
     "AgentThoughts",
     "CommandRepetitionError",
+    "Archaeologist",
+    "ISSUE_DETECTED",
+    "DIAGNOSIS_COMPLETE",
 ]

--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Event-driven diagnostic agent for plugin issues."""
+
+import ast
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from autogpt.event_bus import EventMessage, MessageQueue
+
+ISSUE_DETECTED = "ISSUE_DETECTED"
+"""Event type indicating that a plugin issue was detected."""
+
+DIAGNOSIS_COMPLETE = "DIAGNOSIS_COMPLETE"
+"""Event type emitted after diagnostic analysis is completed."""
+
+
+class Archaeologist:
+    """Agent that inspects issues reported by plugins and emits diagnostics."""
+
+    def __init__(self, message_queue: MessageQueue) -> None:
+        self.message_queue = message_queue
+        self.message_queue.subscribe(ISSUE_DETECTED, self._on_issue_detected)
+
+    # ------------------------------------------------------------------
+    def _on_issue_detected(self, event: EventMessage) -> None:
+        """Handle an ISSUE_DETECTED event."""
+
+        payload = event.payload or {}
+        if not isinstance(payload, dict):
+            return
+
+        plugin_id = payload.get("plugin")
+        error_log = payload.get("error_log")
+        metadata = {
+            k: v for k, v in payload.items() if k not in {"plugin", "error_log"}
+        }
+
+        analysis = {
+            "checkout": self._checkout_commit(metadata.get("commit")),
+            "blame": self._git_blame(metadata.get("file"), metadata.get("line")),
+            "dependencies": self._review_dependencies(metadata.get("file")),
+        }
+
+        diagnosis = {
+            "plugin": plugin_id,
+            "error_log": error_log,
+            "metadata": metadata,
+            "analysis": analysis,
+            "recommendations": self._recommendations(analysis),
+        }
+
+        self.message_queue.publish(
+            EventMessage(
+                event_type=DIAGNOSIS_COMPLETE,
+                payload=diagnosis,
+                source_agent="archaeologist",
+            )
+        )
+
+    # ------------------------------------------------------------------
+    def _checkout_commit(self, commit: str | None) -> str | None:
+        """Checkout the specified commit and return git output."""
+
+        if not commit:
+            return None
+
+        current = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        result = subprocess.run(
+            ["git", "checkout", commit], capture_output=True, text=True
+        )
+        subprocess.run(["git", "checkout", current], capture_output=True, text=True)
+        return result.stdout + result.stderr
+
+    def _git_blame(self, file: str | None, line: int | None) -> str | None:
+        """Run git blame on the specified file and line."""
+
+        if not file:
+            return None
+        cmd = ["git", "blame"]
+        if line is not None:
+            cmd += ["-L", f"{line},{line}"]
+        cmd.append(file)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return result.stdout.strip()
+
+    def _review_dependencies(self, file: str | None) -> list[str]:
+        """Collect imported modules from ``file``."""
+
+        if not file or not Path(file).exists():
+            return []
+        try:
+            tree = ast.parse(Path(file).read_text())
+        except Exception:
+            return []
+        deps: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                deps.extend(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                deps.append(node.module.split(".")[0])
+        return sorted(set(deps))
+
+    def _recommendations(self, analysis: dict[str, Any]) -> str:
+        """Create a simple recommendation string from analysis data."""
+
+        recs: list[str] = []
+        if analysis.get("blame"):
+            recs.append("Review the blamed lines for potential fixes.")
+        deps = analysis.get("dependencies") or []
+        if deps:
+            recs.append("Check versions of dependencies: " + ", ".join(deps))
+        return " ".join(recs) if recs else "No recommendations."

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+from autogpt.event_bus import EventBus, EventMessage, MessageQueue
+
+# Avoid importing autogpt.agents package initializer with heavy dependencies
+agents_pkg = types.ModuleType("autogpt.agents")
+agents_pkg.__path__ = ["autogpt/agents"]
+sys.modules.setdefault("autogpt.agents", agents_pkg)
+
+arch_module = importlib.import_module("autogpt.agents.archaeologist")
+Archaeologist = arch_module.Archaeologist
+ISSUE_DETECTED = arch_module.ISSUE_DETECTED
+DIAGNOSIS_COMPLETE = arch_module.DIAGNOSIS_COMPLETE
+
+
+def test_archaeologist_handles_issue(tmp_path: Path) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    archaeologist = Archaeologist(message_queue)
+
+    received: list[EventMessage] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    payload = {
+        "plugin": "test_plugin",
+        "error_log": "traceback",
+        "commit": "HEAD",
+        "file": "autogpt/agents/agent.py",
+        "line": 10,
+        "extra": "meta",
+    }
+
+    message_queue.publish(
+        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+    )
+
+    assert len(received) == 1
+    diag = received[0].payload
+    assert diag["plugin"] == "test_plugin"
+    assert diag["error_log"] == "traceback"
+    assert "analysis" in diag
+    assert "recommendations" in diag


### PR DESCRIPTION
## Summary
- add `Archaeologist` agent that reacts to `ISSUE_DETECTED` events and publishes `DIAGNOSIS_COMPLETE`
- include helper functions for git checkout, blame, and dependency review
- export agent and event names, plus unit test for the new workflow

## Testing
- `pre-commit run --files autogpt/agents/archaeologist.py autogpt/agents/__init__.py tests/unit/test_archaeologist.py` (skipping autoflake, pytest-check)
- `pytest --noconftest tests/unit/test_archaeologist.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d6983788832fb1b19f65ce5fd639