### PR TITLE
docs: describe message queue architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,50 @@ cp .env.template .env
 若使用 Azure OpenAI，请设置 `USE_AZURE=true` 并将 `azure.yaml.template` 复制为
 `azure.yaml`，然后填写所需字段。
 
+## 消息队列
+
+Auto-GPT 包含用于代理之间通信的轻量级消息队列与事件总线。
+
+- **MessageQueue**：若安装了 [PyPubSub](https://github.com/schollii/pypubsub) 将使用该
+  后端，否则回退到内存实现。
+- **EventBus**：可选组件，将事件写入工作区中的 `events.db` 以便调试和追踪。
+
+### 安装默认后端
+
+```bash
+pip install pypubsub
+```
+
+也可以运行 Redis、RabbitMQ 等外部消息代理并实现自定义后端：
+
+```bash
+docker run -p 6379:6379 redis
+docker run -p 5672:5672 rabbitmq
+```
+
+### 事件格式
+
+事件使用 `EventMessage` 数据类：
+
+```python
+EventMessage(event_type="example", payload={"foo": "bar"}, source_agent="agent-1")
+```
+
+### 发布与订阅示例
+
+```python
+from autogpt.event_bus import EventBus, MessageQueue, EventMessage
+
+bus = EventBus("events.db")
+queue = MessageQueue(bus)
+
+def handler(event: EventMessage):
+    print(event.payload)
+
+queue.subscribe("example", handler)
+queue.publish(EventMessage(event_type="example", payload={"foo": "bar"}, source_agent="demo"))
+```
+
 ## 运行应用
 
 ```bash

--- a/docs/configuration/message_queue.md
+++ b/docs/configuration/message_queue.md
@@ -1,0 +1,96 @@
+# Message Queue
+
+Auto-GPT includes a lightweight publish/subscribe system for agents to exchange events.
+It consists of a `MessageQueue` for in-memory dispatch and an optional `EventBus`
+that persists events to a SQLite database.
+
+## Architecture
+
+```text
+Agent -> MessageQueue -> (PyPubSub backend | in-process fallback) -> Subscribers
+                                  |
+                                  -> EventBus (SQLite)
+```
+
+* **MessageQueue** – routes messages between agents. If the optional
+  [PyPubSub](https://github.com/schollii/pypubsub) package is installed, it is
+  used as a backend; otherwise Auto-GPT falls back to an internal dispatcher.
+* **EventBus** – persists every event in `events.db` inside the agent's workspace
+  for later inspection.
+
+## Configuration
+
+No configuration is required to use the built‑in queue. Installing PyPubSub
+is recommended for cross-module communication. The event database is created
+at `<workspace>/events.db` by default.
+
+### Installing the default backend (PyPubSub)
+
+```bash
+pip install pypubsub
+```
+
+### Alternative brokers
+
+You can run an external message broker and provide your own backend
+integration. Example commands to start common brokers locally:
+
+```bash
+# Redis
+docker run -p 6379:6379 redis
+
+# RabbitMQ
+docker run -p 5672:5672 rabbitmq
+```
+
+## Message format
+
+Events use the `EventMessage` dataclass:
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+@dataclass
+class EventMessage:
+    event_type: str
+    payload: dict[str, Any] | str | None = None
+    source_agent: str | None = None
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+```
+
+## Examples
+
+### Publishing an event
+
+```python
+from autogpt.event_bus import EventBus, EventMessage, MessageQueue
+
+bus = EventBus("events.db")
+queue = MessageQueue(bus)
+
+queue.publish(
+    EventMessage(event_type="status", payload={"msg": "hi"}, source_agent="agent"),
+)
+```
+
+### Subscribing to events
+
+```python
+from autogpt.event_bus import EventMessage
+
+
+def handle_status(event: EventMessage) -> None:
+    print(event.payload)
+
+queue.subscribe("status", handle_status)
+```
+
+### Reading persisted events
+
+```python
+for event in queue.get_events():
+    print(event)
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - 选项: configuration/options.md
       - 搜索: configuration/search.md
       - 记忆: configuration/memory.md
+      - 消息队列: configuration/message_queue.md
       - 语音: configuration/voice.md
       - 图像生成: configuration/imagegen.md
 


### PR DESCRIPTION
## Summary
- document the message queue/EventBus system and configuration
- add setup instructions and examples for message publishing/subscribing
- link new queue documentation in the docs navigation

## Testing
- `pre-commit run --files README.md mkdocs.yml docs/configuration/message_queue.md` *(failed: ModuleNotFoundError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6890d697efe8832f9d9df63f6673bf7c