### PR TITLE
Add git helper utilities

### DIFF
--- a/autogpt/utils/__init__.py
+++ b/autogpt/utils/__init__.py
@@ -1,8 +1,19 @@
+"""General-purpose utilities for AutoGPT."""
+
+from __future__ import annotations
+
 import yaml
 from colorama import Fore
 
+from .git import git_checkout, git_blame
+
 
 def validate_yaml_file(file: str):
+    """Validate a YAML file.
+
+    Returns a tuple ``(bool, message)`` indicating validity and a human readable
+    message describing the result.
+    """
     try:
         with open(file, encoding="utf-8") as fp:
             yaml.load(fp.read(), Loader=yaml.FullLoader)
@@ -15,3 +26,6 @@ def validate_yaml_file(file: str):
         )
 
     return (True, f"Successfully validated {Fore.CYAN}`{file}`{Fore.RESET}!")
+
+
+__all__ = ["git_checkout", "git_blame", "validate_yaml_file"]

--- a/autogpt/utils/git.py
+++ b/autogpt/utils/git.py
@@ -1,0 +1,127 @@
+"""Helpers for interacting with Git repositories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from git import Repo
+from git.exc import GitCommandError, InvalidGitRepositoryError, NoSuchPathError
+
+
+class GitError(RuntimeError):
+    """Raised when a git operation cannot be completed."""
+
+
+def _get_repo(repo_path: Path) -> Repo:
+    """Load a Git repository from ``repo_path``.
+
+    Raises:
+        FileNotFoundError: If the path does not exist or is not a git repository.
+    """
+
+    try:
+        return Repo(repo_path)
+    except (InvalidGitRepositoryError, NoSuchPathError):  # pragma: no cover - error path
+        raise FileNotFoundError(f"Repository not found at {repo_path}")
+
+
+def git_checkout(repo_path: str | Path, commit_or_branch: str) -> Dict[str, str]:
+    """Checkout ``commit_or_branch`` in the repository located at ``repo_path``.
+
+    Parameters
+    ----------
+    repo_path
+        Path to the repository working tree.
+    commit_or_branch
+        Commit hash or branch name to check out.
+
+    Returns
+    -------
+    dict
+        Information about the checked out commit with keys:
+        ``commit_hash``, ``author``, ``timestamp``, ``code`` (commit message).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``repo_path`` does not point to a valid Git repository.
+    ValueError
+        If ``commit_or_branch`` does not exist in the repository.
+    """
+
+    repo = _get_repo(Path(repo_path))
+
+    try:
+        repo.git.checkout(commit_or_branch)
+    except GitCommandError as e:  # pragma: no cover - exercised in tests
+        raise ValueError(f"Could not checkout '{commit_or_branch}': {e}")
+
+    commit = repo.head.commit
+    return {
+        "commit_hash": commit.hexsha,
+        "author": commit.author.name,
+        "timestamp": commit.committed_datetime.isoformat(),
+        # Using the commit message as a snippet describing the checkout
+        "code": commit.message.strip(),
+    }
+
+
+def git_blame(file_path: str | Path, line_number: int) -> Dict[str, str]:
+    """Return blame information for ``line_number`` in ``file_path``.
+
+    Parameters
+    ----------
+    file_path
+        Path to the file to blame.
+    line_number
+        1-indexed line number within the file.
+
+    Returns
+    -------
+    dict
+        Information about the blamed line with keys:
+        ``commit_hash``, ``author``, ``timestamp``, ``code`` (line contents).
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file or repository does not exist.
+    ValueError
+        If ``line_number`` is out of range for the file.
+    """
+
+    if line_number < 1:
+        raise ValueError("line_number must be greater than zero")
+
+    path = Path(file_path)
+    if not path.exists():  # pragma: no cover - error path
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    try:
+        repo = Repo(path.parent, search_parent_directories=True)
+    except (InvalidGitRepositoryError, NoSuchPathError):  # pragma: no cover
+        raise FileNotFoundError(f"No git repository found for {file_path}")
+
+    rel_path = path.relative_to(repo.working_tree_dir)
+
+    try:
+        blame_data = repo.blame("HEAD", str(rel_path))
+    except GitCommandError as e:  # pragma: no cover - error path
+        raise ValueError(f"Could not retrieve blame for {file_path}: {e}")
+
+    current_line = 1
+    for commit, lines in blame_data:
+        if current_line <= line_number <= current_line + len(lines) - 1:
+            line = lines[line_number - current_line]
+            return {
+                "commit_hash": commit.hexsha,
+                "author": commit.author.name,
+                "timestamp": commit.committed_datetime.isoformat(),
+                "code": line.rstrip("\n"),
+            }
+        current_line += len(lines)
+
+    raise ValueError(
+        f"Line number {line_number} out of range for file '{file_path}'"
+    )

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -1,0 +1,64 @@
+import pytest
+from pathlib import Path
+from git import Repo, Actor
+
+from autogpt.utils.git import git_checkout, git_blame
+
+
+@pytest.fixture
+def init_repo(tmp_path: Path):
+    repo_path = tmp_path / "repo"
+    repo = Repo.init(repo_path)
+    file_path = repo_path / "file.txt"
+    author = Actor("Test User", "test@example.com")
+
+    file_path.write_text("line1\nline2\n")
+    repo.index.add([str(file_path)])
+    commit1 = repo.index.commit("initial", author=author, committer=author)
+
+    file_path.write_text("line1 changed\nline2\n")
+    repo.index.add([str(file_path)])
+    commit2 = repo.index.commit("second", author=author, committer=author)
+
+    return repo_path, file_path, commit1, commit2
+
+
+def test_git_checkout_success(init_repo):
+    repo_path, file_path, commit1, commit2 = init_repo
+
+    result = git_checkout(str(repo_path), commit1.hexsha)
+
+    assert result["commit_hash"] == commit1.hexsha
+    assert file_path.read_text() == "line1\nline2\n"
+
+
+def test_git_checkout_invalid_revision(init_repo):
+    repo_path, _, _, _ = init_repo
+    with pytest.raises(ValueError):
+        git_checkout(str(repo_path), "missing-branch")
+
+
+def test_git_blame_success(init_repo):
+    repo_path, file_path, commit1, commit2 = init_repo
+
+    result = git_blame(str(file_path), 1)
+
+    assert result["commit_hash"] == commit2.hexsha
+    assert result["code"] == "line1 changed"
+
+
+def test_git_blame_out_of_range(init_repo):
+    _, file_path, _, _ = init_repo
+    with pytest.raises(ValueError):
+        git_blame(str(file_path), 10)
+
+
+def test_git_blame_no_repo(tmp_path: Path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+    with pytest.raises(FileNotFoundError):
+        git_blame(str(file_path), 1)
+
+def test_git_checkout_missing_repo(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        git_checkout(str(tmp_path / "missing"), "main")


### PR DESCRIPTION
## Summary
- add `git_checkout` and `git_blame` helper functions returning commit metadata
- convert `autogpt.utils` into a package and preserve existing helpers
- cover new git utilities with unit tests

## Testing
- `pytest tests/unit/test_git_utils.py --confcutdir=tests/unit -q`
- `pytest tests/unit/test_git_commands.py::test_git_checkout_success tests/unit/test_git_commands.py::test_git_checkout_error tests/unit/test_git_commands.py::test_git_blame_success tests/unit/test_git_commands.py::test_git_blame_error -q`
- `pytest tests/unit/test_utils.py::test_validate_yaml_file_valid tests/unit/test_utils.py::test_validate_yaml_file_not_found tests/unit/test_utils.py::test_validate_yaml_file_invalid --confcutdir=tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d9750f48832f882ace693b98fada