### PR TITLE
feat: parse log lines for archaeologist agent

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 """Event-driven diagnostic agent for plugin issues."""
 
 import ast
+import re
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from autogpt.event_bus import EventMessage, MessageQueue
 
@@ -37,6 +38,13 @@ class Archaeologist:
             k: v for k, v in payload.items() if k not in {"plugin", "error_log"}
         }
 
+        if error_log and ("file" not in metadata or "line" not in metadata):
+            file, line = next(self._parse_log(error_log), (None, None))
+            if "file" not in metadata and file:
+                metadata["file"] = file
+            if "line" not in metadata and line is not None:
+                metadata["line"] = line
+
         analysis = {
             "checkout": self._checkout_commit(metadata.get("commit")),
             "blame": self._git_blame(metadata.get("file"), metadata.get("line")),
@@ -58,6 +66,28 @@ class Archaeologist:
                 source_agent="archaeologist",
             )
         )
+
+    # ------------------------------------------------------------------
+    def _parse_log(self, log: str) -> Iterator[tuple[str, int]]:
+        """Yield ``(file, line)`` pairs parsed from *log*.
+
+        Supports common Python tracebacks and generic ``path:line`` formats
+        often used by plugins. Gracefully yields nothing if no matches are
+        found so callers can fall back to other metadata.
+        """
+
+        patterns = [
+            re.compile(r'File "(?P<file>[^"\n]+)", line (?P<line>\d+)'),
+            re.compile(r'(?P<file>[\w./\\-]+):(?P<line>\d+)'),
+        ]
+        for entry in log.splitlines():
+            for pattern in patterns:
+                match = pattern.search(entry)
+                if match:
+                    try:
+                        yield match.group("file"), int(match.group("line"))
+                    except (ValueError, AttributeError):
+                        continue
 
     # ------------------------------------------------------------------
     def _checkout_commit(self, commit: str | None) -> str | None:

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -43,3 +43,73 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     assert diag["error_log"] == "traceback"
     assert "analysis" in diag
     assert "recommendations" in diag
+
+
+def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    Archaeologist(message_queue)
+
+    received: list[EventMessage] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    payload = {
+        "plugin": "test_plugin",
+        "error_log": (
+            "Traceback (most recent call last):\n"
+            "  File \"autogpt/agents/agent.py\", line 42, in <module>\n"
+            "    raise Exception()\n"
+        ),
+    }
+
+    message_queue.publish(
+        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+    )
+
+    diag = received[0].payload
+    assert diag["metadata"]["file"] == "autogpt/agents/agent.py"
+    assert diag["metadata"]["line"] == 42
+
+
+def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    Archaeologist(message_queue)
+
+    received: list[EventMessage] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    payload = {
+        "plugin": "test_plugin",
+        "error_log": "ERROR at autogpt/agents/agent.py:50 something went wrong",
+    }
+
+    message_queue.publish(
+        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+    )
+
+    diag = received[0].payload
+    assert diag["metadata"]["file"] == "autogpt/agents/agent.py"
+    assert diag["metadata"]["line"] == 50
+
+
+def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    Archaeologist(message_queue)
+
+    received: list[EventMessage] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    payload = {
+        "plugin": "test_plugin",
+        "error_log": "unstructured log message",
+    }
+
+    message_queue.publish(
+        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+    )
+
+    diag = received[0].payload
+    assert "file" not in diag["metadata"]
+    assert "line" not in diag["metadata"]


### PR DESCRIPTION
## Summary
- parse file and line information from plugin error logs
- support Python tracebacks and generic `path:line` formats
- handle unparseable logs gracefully

## Testing
- `pytest tests/unit/test_archaeologist.py`


------
https://chatgpt.com/codex/tasks/task_e_6890de390278832fba9f047bc80f76e9