### PR TITLE
Add dependency analysis for archaeologist agent

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from autogpt.event_bus import EventMessage, MessageQueue
 
+from .archaeologist_dependency import analyze_dependency
+
 ISSUE_DETECTED = "ISSUE_DETECTED"
 """Event type indicating that a plugin issue was detected."""
 
@@ -89,22 +91,28 @@ class Archaeologist:
         result = subprocess.run(cmd, capture_output=True, text=True)
         return result.stdout.strip()
 
-    def _review_dependencies(self, file: str | None) -> list[str]:
-        """Collect imported modules from ``file``."""
+    def _review_dependencies(self, file: str | None) -> list[dict[str, Any]]:
+        """Analyze imported modules from ``file`` for compatibility issues."""
 
         if not file or not Path(file).exists():
             return []
         try:
-            tree = ast.parse(Path(file).read_text())
+            source_path = Path(file)
+            tree = ast.parse(source_path.read_text())
         except Exception:
             return []
+
         deps: list[str] = []
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 deps.extend(alias.name.split(".")[0] for alias in node.names)
             elif isinstance(node, ast.ImportFrom) and node.module:
                 deps.append(node.module.split(".")[0])
-        return sorted(set(deps))
+
+        analyses: list[dict[str, Any]] = []
+        for dep in sorted(set(deps)):
+            analyses.append(analyze_dependency(dep, source_path))
+        return analyses
 
     def _recommendations(self, analysis: dict[str, Any]) -> str:
         """Create a simple recommendation string from analysis data."""
@@ -114,5 +122,14 @@ class Archaeologist:
             recs.append("Review the blamed lines for potential fixes.")
         deps = analysis.get("dependencies") or []
         if deps:
-            recs.append("Check versions of dependencies: " + ", ".join(deps))
+            problematic = [d["dependency"] for d in deps if d.get("findings")]
+            if problematic:
+                recs.append(
+                    "Investigate compatibility issues in: " + ", ".join(problematic)
+                )
+            else:
+                recs.append(
+                    "Check versions of dependencies: "
+                    + ", ".join(d["dependency"] for d in deps)
+                )
         return " ".join(recs) if recs else "No recommendations."

--- a/autogpt/agents/archaeologist_dependency.py
+++ b/autogpt/agents/archaeologist_dependency.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Dependency analysis utilities for the Archaeologist agent."""
+
+import ast
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import requests
+
+
+def fetch_release_notes(package: str, version: str | None) -> str | None:
+    """Fetch release notes for ``package`` at ``version`` from PyPI.
+
+    If fetching fails, ``None`` is returned.
+    """
+
+    if not version:
+        return None
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
+    try:
+        resp = requests.get(url, timeout=5)
+        if resp.ok:
+            data = resp.json()
+            return data.get("info", {}).get("description") or None
+    except Exception:
+        return None
+    return None
+
+
+def scan_for_usage(source: Path, package: str) -> Set[str]:
+    """Scan ``source`` for imports or API calls related to ``package``.
+
+    Returns a set of fully qualified names used in the file.
+    """
+
+    try:
+        tree = ast.parse(source.read_text())
+    except Exception:
+        return set()
+
+    aliases: Dict[str, str] = {}
+    usages: Set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == package:
+                    aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.module.split(".")[0] == package:
+                module = node.module
+                for alias in node.names:
+                    aliases[alias.asname or alias.name] = f"{module}.{alias.name}"
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                value = func.value
+                if isinstance(value, ast.Name) and value.id in aliases:
+                    usages.add(f"{aliases[value.id]}.{func.attr}")
+            elif isinstance(func, ast.Name) and func.id in aliases:
+                usages.add(aliases[func.id])
+    return usages
+
+
+def analyze_dependency(package: str, source: Path) -> Dict[str, Any]:
+    """Analyze ``package`` usage within ``source`` and check release notes."""
+
+    version: str | None = None
+    try:
+        version = metadata.version(package)
+    except Exception:
+        pass
+
+    release_notes = fetch_release_notes(package, version)
+    usages = scan_for_usage(source, package)
+
+    findings: list[str] = []
+    if release_notes:
+        lowered = release_notes.lower()
+        for usage in usages:
+            name = usage.split(".")[-1].lower()
+            if name in lowered and any(
+                kw in lowered for kw in ["deprecated", "removed", "breaking"]
+            ):
+                findings.append(f"{usage} may be incompatible with {package} {version}")
+        if not findings and any(
+            kw in lowered for kw in ["deprecated", "removed", "breaking"]
+        ):
+            findings.append(
+                f"{package} {version} release notes mention potential breaking changes"
+            )
+
+    return {
+        "dependency": package,
+        "version": version,
+        "usages": sorted(usages),
+        "release_notes": release_notes,
+        "findings": findings,
+    }


### PR DESCRIPTION
## Summary
- add archaeologist dependency analyzer to collect release notes and scan plugin code for API calls
- use dependency analyzer in Archaeologist agent and surface compatibility warnings in recommendations

## Testing
- `pre-commit run isort --files autogpt/agents/archaeologist_dependency.py autogpt/agents/archaeologist.py`
- `pre-commit run black --files autogpt/agents/archaeologist_dependency.py autogpt/agents/archaeologist.py`
- `pre-commit run mypy --files autogpt/agents/archaeologist_dependency.py autogpt/agents/archaeologist.py`
- `pytest tests/unit/test_archaeologist.py` *(fails: ModuleNotFoundError: No module named 'ftfy')*


------
https://chatgpt.com/codex/tasks/task_e_6890dead09b8832fa0c2322acc17dd74