### PR TITLE
feat: add diagnosis complete event

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -8,15 +8,12 @@ import subprocess
 from pathlib import Path
 from typing import Any, Iterator
 
-from autogpt.event_bus import EventMessage, MessageQueue
+from autogpt.event_bus import DiagnosisComplete, EventMessage, MessageQueue
 
 from .archaeologist_dependency import analyze_dependency
 
 ISSUE_DETECTED = "ISSUE_DETECTED"
 """Event type indicating that a plugin issue was detected."""
-
-DIAGNOSIS_COMPLETE = "DIAGNOSIS_COMPLETE"
-"""Event type emitted after diagnostic analysis is completed."""
 
 
 class Archaeologist:
@@ -53,18 +50,22 @@ class Archaeologist:
             "dependencies": self._review_dependencies(metadata.get("file")),
         }
 
-        diagnosis = {
-            "plugin": plugin_id,
-            "error_log": error_log,
-            "metadata": metadata,
-            "analysis": analysis,
-            "recommendations": self._recommendations(analysis),
-        }
+        recommendations = self._recommendations(analysis)
+
+        summary_parts = [
+            f"Diagnostics for plugin {plugin_id}" if plugin_id else "Diagnostics"
+        ]
+        if metadata.get("file"):
+            location = metadata["file"]
+            if metadata.get("line") is not None:
+                location += f":{metadata['line']}"
+            summary_parts.append(f"at {location}")
+        summary = " ".join(summary_parts)
 
         self.message_queue.publish(
-            EventMessage(
-                event_type=DIAGNOSIS_COMPLETE,
-                payload=diagnosis,
+            DiagnosisComplete(
+                summary=summary,
+                actionable_recommendations=recommendations,
                 source_agent="archaeologist",
             )
         )
@@ -80,7 +81,7 @@ class Archaeologist:
 
         patterns = [
             re.compile(r'File "(?P<file>[^"\n]+)", line (?P<line>\d+)'),
-            re.compile(r'(?P<file>[\w./\\-]+):(?P<line>\d+)'),
+            re.compile(r"(?P<file>[\w./\\-]+):(?P<line>\d+)"),
         ]
         for entry in log.splitlines():
             for pattern in patterns:

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
-from .message_types import EventMessage
+from .message_types import DIAGNOSIS_COMPLETE, DiagnosisComplete, EventMessage
 
 
 class EventBus:
@@ -59,14 +59,31 @@ class EventBus:
                 payload_obj = json.loads(payload)
             except Exception:
                 payload_obj = payload
-            yield EventMessage(
-                event_type=et,
-                payload=payload_obj,
-                source_agent=source_agent,
-                timestamp=ts,
-            )
+
+            if et == DIAGNOSIS_COMPLETE and isinstance(payload_obj, dict):
+                yield DiagnosisComplete(
+                    summary=str(payload_obj.get("summary", "")),
+                    actionable_recommendations=str(
+                        payload_obj.get("actionable_recommendations", "")
+                    ),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
+            else:
+                yield EventMessage(
+                    event_type=et,
+                    payload=payload_obj,
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
 
 
 from .message_queue import MessageQueue
 
-__all__ = ["EventBus", "MessageQueue", "EventMessage"]
+__all__ = [
+    "EventBus",
+    "MessageQueue",
+    "EventMessage",
+    "DiagnosisComplete",
+    "DIAGNOSIS_COMPLETE",
+]

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -13,3 +13,26 @@ class EventMessage:
     payload: dict[str, Any] | str | None = None
     source_agent: str | None = None
     timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+DIAGNOSIS_COMPLETE = "DIAGNOSIS_COMPLETE"
+"""Event type emitted when diagnostic analysis finishes."""
+
+
+@dataclass(kw_only=True)
+class DiagnosisComplete(EventMessage):
+    """Schema for :data:`DIAGNOSIS_COMPLETE` events."""
+
+    summary: str
+    actionable_recommendations: str
+    event_type: str = field(init=False, default=DIAGNOSIS_COMPLETE)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "summary": self.summary,
+            "actionable_recommendations": self.actionable_recommendations,
+        }
+
+
+__all__ = ["EventMessage", "DiagnosisComplete", "DIAGNOSIS_COMPLETE"]

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -3,7 +3,13 @@ import sys
 import types
 from pathlib import Path
 
-from autogpt.event_bus import EventBus, EventMessage, MessageQueue
+from autogpt.event_bus import (
+    DIAGNOSIS_COMPLETE,
+    DiagnosisComplete,
+    EventBus,
+    EventMessage,
+    MessageQueue,
+)
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
 agents_pkg = types.ModuleType("autogpt.agents")
@@ -13,15 +19,14 @@ sys.modules.setdefault("autogpt.agents", agents_pkg)
 arch_module = importlib.import_module("autogpt.agents.archaeologist")
 Archaeologist = arch_module.Archaeologist
 ISSUE_DETECTED = arch_module.ISSUE_DETECTED
-DIAGNOSIS_COMPLETE = arch_module.DIAGNOSIS_COMPLETE
 
 
 def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    archaeologist = Archaeologist(message_queue)
+    Archaeologist(message_queue)
 
-    received: list[EventMessage] = []
+    received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
     payload = {
@@ -38,11 +43,9 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     )
 
     assert len(received) == 1
-    diag = received[0].payload
-    assert diag["plugin"] == "test_plugin"
-    assert diag["error_log"] == "traceback"
-    assert "analysis" in diag
-    assert "recommendations" in diag
+    diag = received[0]
+    assert "test_plugin" in diag.summary
+    assert isinstance(diag.actionable_recommendations, str)
 
 
 def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
@@ -50,14 +53,14 @@ def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
     message_queue = MessageQueue(event_bus)
     Archaeologist(message_queue)
 
-    received: list[EventMessage] = []
+    received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
     payload = {
         "plugin": "test_plugin",
         "error_log": (
             "Traceback (most recent call last):\n"
-            "  File \"autogpt/agents/agent.py\", line 42, in <module>\n"
+            '  File "autogpt/agents/agent.py", line 42, in <module>\n'
             "    raise Exception()\n"
         ),
     }
@@ -66,9 +69,7 @@ def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
         EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
     )
 
-    diag = received[0].payload
-    assert diag["metadata"]["file"] == "autogpt/agents/agent.py"
-    assert diag["metadata"]["line"] == 42
+    assert "autogpt/agents/agent.py:42" in received[0].summary
 
 
 def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
@@ -76,7 +77,7 @@ def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
     message_queue = MessageQueue(event_bus)
     Archaeologist(message_queue)
 
-    received: list[EventMessage] = []
+    received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
     payload = {
@@ -88,9 +89,7 @@ def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
         EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
     )
 
-    diag = received[0].payload
-    assert diag["metadata"]["file"] == "autogpt/agents/agent.py"
-    assert diag["metadata"]["line"] == 50
+    assert "autogpt/agents/agent.py:50" in received[0].summary
 
 
 def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
@@ -98,7 +97,7 @@ def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
     message_queue = MessageQueue(event_bus)
     Archaeologist(message_queue)
 
-    received: list[EventMessage] = []
+    received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
     payload = {
@@ -110,6 +109,4 @@ def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
         EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
     )
 
-    diag = received[0].payload
-    assert "file" not in diag["metadata"]
-    assert "line" not in diag["metadata"]
+    assert "autogpt/agents/agent.py" not in received[0].summary

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -2,7 +2,13 @@ from pathlib import Path
 
 import pytest
 
-from autogpt.event_bus import EventBus, EventMessage, MessageQueue
+from autogpt.event_bus import (
+    DIAGNOSIS_COMPLETE,
+    DiagnosisComplete,
+    EventBus,
+    EventMessage,
+    MessageQueue,
+)
 
 
 @pytest.fixture
@@ -30,6 +36,27 @@ def test_event_bus_emit_and_read(event_bus: EventBus) -> None:
     assert isinstance(events[0].payload, dict)
     assert events[0].payload["foo"] == "bar"
     assert events[0].source_agent == "test"
+
+
+def test_message_queue_diagnosis_complete(message_queue: MessageQueue) -> None:
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    event = DiagnosisComplete(
+        summary="Diagnostics complete",
+        actionable_recommendations="Fix it",
+        source_agent="archaeologist",
+    )
+    message_queue.publish(event)
+
+    assert len(received) == 1
+    assert isinstance(received[0], DiagnosisComplete)
+    assert received[0].summary == "Diagnostics complete"
+
+    events = list(message_queue.get_events())
+    assert len(events) == 1
+    assert isinstance(events[0], DiagnosisComplete)
+    assert events[0].summary == "Diagnostics complete"
 
 
 def test_message_queue_publish_from_multiple_sources(


### PR DESCRIPTION
## Summary
- define DIAGNOSIS_COMPLETE event schema
- publish diagnosis events from Archaeologist agent
- exercise publish/subscribe via event bus tests

## Testing
- `pre-commit run --files autogpt/event_bus/message_types.py autogpt/event_bus/__init__.py autogpt/agents/archaeologist.py tests/unit/test_event_bus.py tests/unit/test_archaeologist.py` (failed: ModuleNotFoundError: No module named 'numpy')
- `pytest tests/unit/test_event_bus.py tests/unit/test_archaeologist.py` (failed: ModuleNotFoundError: No module named 'numpy')


------
https://chatgpt.com/codex/tasks/task_e_6890e0c01cd0832fa635aeff192c14de