### PR TITLE
feat: add code fix proposed event

### DIFF
--- a/autogpt/agents/__init__.py
+++ b/autogpt/agents/__init__.py
@@ -1,7 +1,7 @@
 from .agent import Agent, CommandRepetitionError
-from autogpt.event_bus import DIAGNOSIS_COMPLETE
+from autogpt.event_bus import CODE_FIX_PROPOSED, DIAGNOSIS_COMPLETE
 from .archaeologist import ISSUE_DETECTED, Archaeologist
-from .tdd_developer import CODE_FIX_PROPOSED, TDDDeveloper
+from .tdd_developer import TDDDeveloper
 from .base import AgentThoughts, BaseAgent, CommandArgs, CommandName
 
 __all__ = [

--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from git import Repo
+
 from autogpt.agents.agent import Agent
 from autogpt.commands.git_operations import (
     git_checkout,
@@ -12,10 +14,13 @@ from autogpt.commands.git_operations import (
     git_create_branch,
 )
 from autogpt.commands.testing import create_test_file, run_tests
-from autogpt.event_bus import DIAGNOSIS_COMPLETE, EventMessage, MessageQueue
-
-CODE_FIX_PROPOSED = "CODE_FIX_PROPOSED"
-"""Event type emitted when a code fix has been proposed."""
+from autogpt.event_bus import (
+    CODE_FIX_PROPOSED,
+    DIAGNOSIS_COMPLETE,
+    CodeFixProposed,
+    EventMessage,
+    MessageQueue,
+)
 
 
 class TDDDeveloper:
@@ -61,16 +66,16 @@ class TDDDeveloper:
             return
 
         git_commit(repo_path, f"Fix issue {issue_id}", self.agent)
+        try:
+            commit_hash = Repo(repo_path).head.commit.hexsha
+        except Exception:
+            commit_hash = ""
 
         self.message_queue.publish(
-            EventMessage(
-                event_type=CODE_FIX_PROPOSED,
-                payload={
-                    "issue_id": issue_id,
-                    "repo_path": repo_path,
-                    "test_file": str(test_file),
-                    "diagnostics": diagnostics,
-                },
+            CodeFixProposed(
+                branch_name=branch,
+                commit_hash=commit_hash,
+                summary=f"Fix issue {issue_id}",
                 source_agent="tdd_developer",
             )
         )

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -6,7 +6,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
-from .message_types import DIAGNOSIS_COMPLETE, DiagnosisComplete, EventMessage
+from .message_types import (
+    CODE_FIX_PROPOSED,
+    DIAGNOSIS_COMPLETE,
+    CodeFixProposed,
+    DiagnosisComplete,
+    EventMessage,
+)
 
 
 class EventBus:
@@ -69,6 +75,14 @@ class EventBus:
                     source_agent=source_agent,
                     timestamp=ts,
                 )
+            elif et == CODE_FIX_PROPOSED and isinstance(payload_obj, dict):
+                yield CodeFixProposed(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    commit_hash=str(payload_obj.get("commit_hash", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
             else:
                 yield EventMessage(
                     event_type=et,
@@ -85,5 +99,7 @@ __all__ = [
     "MessageQueue",
     "EventMessage",
     "DiagnosisComplete",
+    "CodeFixProposed",
     "DIAGNOSIS_COMPLETE",
+    "CODE_FIX_PROPOSED",
 ]

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -18,6 +18,9 @@ class EventMessage:
 DIAGNOSIS_COMPLETE = "DIAGNOSIS_COMPLETE"
 """Event type emitted when diagnostic analysis finishes."""
 
+CODE_FIX_PROPOSED = "CODE_FIX_PROPOSED"
+"""Event type emitted when a code fix has been proposed."""
+
 
 @dataclass(kw_only=True)
 class DiagnosisComplete(EventMessage):
@@ -35,4 +38,34 @@ class DiagnosisComplete(EventMessage):
         }
 
 
-__all__ = ["EventMessage", "DiagnosisComplete", "DIAGNOSIS_COMPLETE"]
+@dataclass(kw_only=True)
+class CodeFixProposed(EventMessage):
+    """Schema for :data:`CODE_FIX_PROPOSED` events.
+
+    Expected payload fields:
+        branch_name: Branch containing the proposed fix.
+        commit_hash: Hash of the commit with the fix.
+        summary: Short description of the proposed fix.
+    """
+
+    branch_name: str
+    commit_hash: str
+    summary: str
+    event_type: str = field(init=False, default=CODE_FIX_PROPOSED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "commit_hash": self.commit_hash,
+            "summary": self.summary,
+        }
+
+
+__all__ = [
+    "EventMessage",
+    "DiagnosisComplete",
+    "CodeFixProposed",
+    "DIAGNOSIS_COMPLETE",
+    "CODE_FIX_PROPOSED",
+]

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -36,7 +36,7 @@ archaeologist = Archaeologist(message_queue)
 To receive the agent's output, subscribe to `DIAGNOSIS_COMPLETE` events:
 
 ```python
-from autogpt.agents import DIAGNOSIS_COMPLETE
+from autogpt.event_bus import DIAGNOSIS_COMPLETE
 
 message_queue.subscribe(DIAGNOSIS_COMPLETE, handle_diagnostics)
 ```

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -3,7 +3,13 @@ import sys
 import types
 from pathlib import Path
 
-from autogpt.event_bus import DIAGNOSIS_COMPLETE, EventBus, EventMessage, MessageQueue
+from autogpt.event_bus import (
+    CODE_FIX_PROPOSED,
+    DIAGNOSIS_COMPLETE,
+    EventBus,
+    EventMessage,
+    MessageQueue,
+)
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
 agents_pkg = types.ModuleType("autogpt.agents")
@@ -12,7 +18,6 @@ sys.modules.setdefault("autogpt.agents", agents_pkg)
 
 tdd_module = importlib.import_module("autogpt.agents.tdd_developer")
 TDDDeveloper = tdd_module.TDDDeveloper
-CODE_FIX_PROPOSED = tdd_module.CODE_FIX_PROPOSED
 
 def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     event_bus = EventBus(tmp_path / "events.db")
@@ -54,4 +59,6 @@ def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     commit.assert_called_once_with(repo_path, "Fix issue 123", agent)
     assert len(received) == 1
     assert received[0].event_type == CODE_FIX_PROPOSED
-    assert received[0].payload["issue_id"] == "123"
+    assert received[0].payload["branch_name"] == "fix/123"
+    assert received[0].payload["summary"] == "Fix issue 123"
+    assert "commit_hash" in received[0].payload


### PR DESCRIPTION
## Summary
- introduce `CODE_FIX_PROPOSED` event with documented payload
- use event constants instead of raw strings across agents and bus
- update docs and tests for new event API

## Testing
- `pytest tests/unit/test_tdd_developer.py tests/unit/test_event_bus.py tests/unit/test_archaeologist.py tests/unit/test_archaeologist_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e5d21120832fb607ba06e3f8246c