### PR TITLE
feat: add approval workflow event types

### DIFF
--- a/autogpt/agents/__init__.py
+++ b/autogpt/agents/__init__.py
@@ -1,7 +1,13 @@
 from .agent import Agent, CommandRepetitionError
-from autogpt.event_bus import CODE_FIX_PROPOSED, DIAGNOSIS_COMPLETE
+from autogpt.event_bus import (
+    APPROVAL_GRANTED,
+    CODE_FIX_PROPOSED,
+    DIAGNOSIS_COMPLETE,
+    HUMAN_APPROVAL_REQUIRED,
+    ISSUE_RESOLVED,
+)
 from .archaeologist import ISSUE_DETECTED, Archaeologist
-from .qa_agent import HUMAN_APPROVAL_REQUIRED, ISSUE_RESOLVED, QAAgent
+from .qa_agent import QAAgent
 from .tdd_developer import TDDDeveloper
 from .base import AgentThoughts, BaseAgent, CommandArgs, CommandName
 
@@ -18,6 +24,7 @@ __all__ = [
     "TDDDeveloper",
     "QAAgent",
     "HUMAN_APPROVAL_REQUIRED",
+    "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
     "CODE_FIX_PROPOSED",
 ]

--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -10,13 +10,17 @@ from git import Repo
 from autogpt.agents.agent import Agent
 from autogpt.commands.git_operations import git_checkout
 from autogpt.commands.testing import run_tests
-from autogpt.event_bus import CODE_FIX_PROPOSED, EventMessage, MessageQueue
-
-HUMAN_APPROVAL_REQUIRED = "HUMAN_APPROVAL_REQUIRED"
-"""Event type emitted when human approval is needed for a fix."""
-
-ISSUE_RESOLVED = "ISSUE_RESOLVED"
-"""Event type emitted after a fix has been merged and deployed."""
+from autogpt.event_bus import (
+    APPROVAL_GRANTED,
+    CODE_FIX_PROPOSED,
+    HUMAN_APPROVAL_REQUIRED,
+    ISSUE_RESOLVED,
+    ApprovalGranted,
+    CodeFixProposed,
+    HumanApprovalRequired,
+    IssueResolved,
+    MessageQueue,
+)
 
 
 class QAAgent:
@@ -26,19 +30,16 @@ class QAAgent:
         self.agent = agent
         self.message_queue = message_queue
         self.message_queue.subscribe(CODE_FIX_PROPOSED, self._on_code_fix_proposed)
+        self.message_queue.subscribe(APPROVAL_GRANTED, self._on_approval_granted)
 
     # ------------------------------------------------------------------
-    def _on_code_fix_proposed(self, event: EventMessage) -> None:
+    def _on_code_fix_proposed(self, event: CodeFixProposed) -> None:
         """Handle a ``CODE_FIX_PROPOSED`` event."""
 
         payload: dict[str, Any] | None = event.payload if isinstance(event.payload, dict) else None
-        if not payload:
-            return
+        repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
 
-        branch = payload.get("branch_name")
-        repo_path = payload.get("repo_path", self.agent.config.workspace_path)
-        approved = payload.get("approved", False)
-
+        branch = event.branch_name
         if not branch or not repo_path:
             return
 
@@ -46,18 +47,23 @@ class QAAgent:
 
         test_output = run_tests(repo_path, self.agent)
 
-        if not approved:
-            self.message_queue.publish(
-                EventMessage(
-                    event_type=HUMAN_APPROVAL_REQUIRED,
-                    payload={
-                        "branch_name": branch,
-                        "test_output": test_output,
-                        "summary": payload.get("summary", ""),
-                    },
-                    source_agent="qa_agent",
-                )
+        self.message_queue.publish(
+            HumanApprovalRequired(
+                branch_name=branch,
+                test_output=test_output,
+                summary=event.summary,
+                source_agent="qa_agent",
             )
+        )
+
+    def _on_approval_granted(self, event: ApprovalGranted) -> None:
+        """Handle an ``APPROVAL_GRANTED`` event."""
+
+        payload: dict[str, Any] | None = event.payload if isinstance(event.payload, dict) else None
+        repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
+
+        branch = event.branch_name
+        if not branch or not repo_path:
             return
 
         repo = Repo(repo_path)
@@ -70,13 +76,10 @@ class QAAgent:
             pass
 
         self.message_queue.publish(
-            EventMessage(
-                event_type=ISSUE_RESOLVED,
-                payload={
-                    "branch_name": branch,
-                    "commit_hash": payload.get("commit_hash", ""),
-                    "summary": payload.get("summary", ""),
-                },
+            IssueResolved(
+                branch_name=branch,
+                commit_hash=event.commit_hash,
+                summary=event.summary,
                 source_agent="qa_agent",
             )
         )

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -7,11 +7,17 @@ from pathlib import Path
 from typing import Iterable
 
 from .message_types import (
+    APPROVAL_GRANTED,
     CODE_FIX_PROPOSED,
     DIAGNOSIS_COMPLETE,
+    HUMAN_APPROVAL_REQUIRED,
+    ISSUE_RESOLVED,
+    ApprovalGranted,
     CodeFixProposed,
     DiagnosisComplete,
     EventMessage,
+    HumanApprovalRequired,
+    IssueResolved,
 )
 
 
@@ -83,6 +89,30 @@ class EventBus:
                     source_agent=source_agent,
                     timestamp=ts,
                 )
+            elif et == HUMAN_APPROVAL_REQUIRED and isinstance(payload_obj, dict):
+                yield HumanApprovalRequired(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    test_output=str(payload_obj.get("test_output", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
+            elif et == APPROVAL_GRANTED and isinstance(payload_obj, dict):
+                yield ApprovalGranted(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    commit_hash=str(payload_obj.get("commit_hash", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
+            elif et == ISSUE_RESOLVED and isinstance(payload_obj, dict):
+                yield IssueResolved(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    commit_hash=str(payload_obj.get("commit_hash", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
             else:
                 yield EventMessage(
                     event_type=et,
@@ -100,6 +130,12 @@ __all__ = [
     "EventMessage",
     "DiagnosisComplete",
     "CodeFixProposed",
+    "HumanApprovalRequired",
+    "ApprovalGranted",
+    "IssueResolved",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
+    "HUMAN_APPROVAL_REQUIRED",
+    "APPROVAL_GRANTED",
+    "ISSUE_RESOLVED",
 ]

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -7,7 +7,11 @@ from typing import Any
 
 @dataclass
 class EventMessage:
-    """Event message passed through the event bus and message queue."""
+    """Event message passed through the event bus and message queue.
+
+    ``source_agent`` records the component that emitted the event and is
+    stored alongside the payload for later auditing or coordination.
+    """
 
     event_type: str
     payload: dict[str, Any] | str | None = None
@@ -20,6 +24,15 @@ DIAGNOSIS_COMPLETE = "DIAGNOSIS_COMPLETE"
 
 CODE_FIX_PROPOSED = "CODE_FIX_PROPOSED"
 """Event type emitted when a code fix has been proposed."""
+
+HUMAN_APPROVAL_REQUIRED = "HUMAN_APPROVAL_REQUIRED"
+"""Event type emitted when human approval is needed for a fix."""
+
+APPROVAL_GRANTED = "APPROVAL_GRANTED"
+"""Event type emitted once a human reviewer approves a proposed fix."""
+
+ISSUE_RESOLVED = "ISSUE_RESOLVED"
+"""Event type emitted after a fix has been merged and deployed."""
 
 
 @dataclass(kw_only=True)
@@ -62,10 +75,88 @@ class CodeFixProposed(EventMessage):
         }
 
 
+@dataclass(kw_only=True)
+class HumanApprovalRequired(EventMessage):
+    """Schema for :data:`HUMAN_APPROVAL_REQUIRED` events.
+
+    Expected payload fields:
+        branch_name: Branch containing the proposed fix.
+        test_output: Output from the verification test run.
+        summary: Short description of the proposed fix.
+    """
+
+    branch_name: str
+    test_output: str
+    summary: str
+    event_type: str = field(init=False, default=HUMAN_APPROVAL_REQUIRED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "test_output": self.test_output,
+            "summary": self.summary,
+        }
+
+
+@dataclass(kw_only=True)
+class ApprovalGranted(EventMessage):
+    """Schema for :data:`APPROVAL_GRANTED` events.
+
+    Expected payload fields:
+        branch_name: Branch containing the approved fix.
+        commit_hash: Hash of the commit that was approved.
+        summary: Short description of the approved fix.
+    """
+
+    branch_name: str
+    commit_hash: str
+    summary: str
+    event_type: str = field(init=False, default=APPROVAL_GRANTED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "commit_hash": self.commit_hash,
+            "summary": self.summary,
+        }
+
+
+@dataclass(kw_only=True)
+class IssueResolved(EventMessage):
+    """Schema for :data:`ISSUE_RESOLVED` events.
+
+    Expected payload fields:
+        branch_name: Branch that contained the fix.
+        commit_hash: Hash of the commit that resolved the issue.
+        summary: Short description of the resolution.
+    """
+
+    branch_name: str
+    commit_hash: str
+    summary: str
+    event_type: str = field(init=False, default=ISSUE_RESOLVED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "commit_hash": self.commit_hash,
+            "summary": self.summary,
+        }
+
+
 __all__ = [
     "EventMessage",
     "DiagnosisComplete",
     "CodeFixProposed",
+    "HumanApprovalRequired",
+    "ApprovalGranted",
+    "IssueResolved",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
+    "HUMAN_APPROVAL_REQUIRED",
+    "APPROVAL_GRANTED",
+    "ISSUE_RESOLVED",
 ]


### PR DESCRIPTION
## Summary
- add event constants and dataclasses for human approval flow and issue resolution
- wire new event types into EventBus and QA agent
- expose approval events via agents package

## Testing
- `pytest tests/unit/test_tdd_developer_agent.py tests/unit/test_tdd_developer.py`

------
https://chatgpt.com/codex/tasks/task_e_6890f0b9d94c832fb40c7e185fc0ffaf