### PR TITLE
test: add qa agent flow test

### DIFF
--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -1,0 +1,93 @@
+import importlib
+import sys
+import types
+
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from autogpt.event_bus import (
+    APPROVAL_GRANTED,
+    CODE_FIX_PROPOSED,
+    ApprovalGranted,
+    CodeFixProposed,
+    HumanApprovalRequired,
+    IssueResolved,
+)
+
+# Avoid importing autogpt.agents package initializer with heavy dependencies
+agents_pkg = types.ModuleType("autogpt.agents")
+agents_pkg.__path__ = ["autogpt/agents"]
+sys.modules.setdefault("autogpt.agents", agents_pkg)
+
+agent_stub = types.ModuleType("autogpt.agents.agent")
+
+
+class Agent:  # minimal stub to satisfy imports
+    pass
+
+
+agent_stub.Agent = Agent
+sys.modules.setdefault("autogpt.agents.agent", agent_stub)
+
+testing_stub = types.ModuleType("autogpt.commands.testing")
+testing_stub.run_tests = lambda *a, **k: ""
+sys.modules.setdefault("autogpt.commands.testing", testing_stub)
+
+git_ops_stub = types.ModuleType("autogpt.commands.git_operations")
+git_ops_stub.git_checkout = lambda *a, **k: ""
+sys.modules.setdefault("autogpt.commands.git_operations", git_ops_stub)
+
+qa_module = importlib.import_module("autogpt.agents.qa_agent")
+QAAgent = qa_module.QAAgent
+
+
+def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
+    message_queue = mocker.Mock(spec=["subscribe", "publish"])
+    agent = mocker.Mock()
+    agent.config.workspace_path = str(tmp_path)
+
+    QAAgent(agent=agent, message_queue=message_queue)
+
+    assert message_queue.subscribe.call_count == 2
+    callbacks = {call.args[0]: call.args[1] for call in message_queue.subscribe.call_args_list}
+    assert set(callbacks.keys()) == {CODE_FIX_PROPOSED, APPROVAL_GRANTED}
+
+    on_code_fix_proposed = callbacks[CODE_FIX_PROPOSED]
+    on_approval_granted = callbacks[APPROVAL_GRANTED]
+
+    git_checkout = mocker.patch.object(qa_module, "git_checkout")
+    run_tests = mocker.patch.object(qa_module, "run_tests", return_value="tests passed")
+    repo_mock = mocker.MagicMock()
+    repo_mock.git.checkout.return_value = ""
+    repo_mock.git.merge.return_value = ""
+    mocker.patch.object(qa_module, "Repo", return_value=repo_mock)
+    subprocess_run = mocker.patch.object(qa_module.subprocess, "run")
+
+    event = CodeFixProposed(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
+    on_code_fix_proposed(event)
+
+    git_checkout.assert_called_once_with(str(tmp_path), "fix/123", agent)
+    run_tests.assert_called_once_with(str(tmp_path), agent)
+    message_queue.publish.assert_called_once()
+    published_event = message_queue.publish.call_args[0][0]
+    assert isinstance(published_event, HumanApprovalRequired)
+    assert published_event.branch_name == "fix/123"
+    assert published_event.test_output == "tests passed"
+    assert published_event.summary == "Fix bug"
+
+    message_queue.publish.reset_mock()
+
+    approval_event = ApprovalGranted(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
+    on_approval_granted(approval_event)
+
+    repo_mock.git.checkout.assert_called_once_with("main")
+    repo_mock.git.merge.assert_called_once_with("fix/123")
+    subprocess_run.assert_called_once_with(["bash", "scripts/deploy.sh"], cwd=str(tmp_path), check=False)
+    message_queue.publish.assert_called_once()
+    resolved_event = message_queue.publish.call_args[0][0]
+    assert isinstance(resolved_event, IssueResolved)
+    assert resolved_event.branch_name == "fix/123"
+    assert resolved_event.commit_hash == "abc"
+    assert resolved_event.summary == "Fix bug"


### PR DESCRIPTION
## Summary
- test QA agent subscription and flow from CODE_FIX_PROPOSED to ISSUE_RESOLVED

## Testing
- `python - <<'PY'
...pytest command script? we used previously to run tests with stubs. However we can't embed entire script; but for PR, we might just show command executed. We'll show `python - <<'PY'
import ... pytest main
PY` in test results. But to keep message short, maybe just mention we executed tests for file. We'll supply command snippet.
`python - <<'PY'
import sys, types, pathlib, pytest
# stub modules... (see log)
pytest.main(['tests/unit/test_qa_agent.py'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6890f458f660832fb895eb6c9687a231