### PR TITLE
Add skill library with vector search backend

### DIFF
--- a/autogpt/skills/__init__.py
+++ b/autogpt/skills/__init__.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Public API for the skills module."""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from autogpt.config import ConfigBuilder
+
+from .library import Skill, SkillLibrary
+from .vector_db import MemoryVectorDB, VectorDBProvider
+
+_default_library: SkillLibrary | None = None
+
+
+def get_library() -> SkillLibrary:
+    """Return a default :class:`SkillLibrary` instance."""
+
+    global _default_library
+    if _default_library is None:
+        config = ConfigBuilder.build_config_from_env(Path.cwd())
+        _default_library = SkillLibrary(config)
+    return _default_library
+
+
+def add(name: str, code: str, parameters: Dict, description: str) -> Skill:
+    """Add a new skill to the library."""
+
+    return get_library().add_skill(name, code, parameters, description)
+
+
+def get(name: str) -> Optional[Skill]:
+    """Return a skill by name if it exists."""
+
+    return get_library().get_skill(name)
+
+
+def update(
+    name: str,
+    code: str | None = None,
+    parameters: Dict | None = None,
+    description: str | None = None,
+) -> Optional[Skill]:
+    """Update an existing skill."""
+
+    return get_library().update_skill(name, code, parameters, description)
+
+
+def delete(name: str) -> None:
+    """Remove a skill from the library."""
+
+    get_library().delete_skill(name)
+
+
+def list_skills() -> List[Skill]:
+    """Return all stored skills."""
+
+    return get_library().list_skills()
+
+
+def search(query: str, top_k: int = 5) -> List[Skill]:
+    """Search for skills semantically matching ``query``."""
+
+    return get_library().search(query, top_k=top_k)
+
+
+__all__ = [
+    "Skill",
+    "SkillLibrary",
+    "VectorDBProvider",
+    "MemoryVectorDB",
+    "get_library",
+    "add",
+    "get",
+    "update",
+    "delete",
+    "list_skills",
+    "search",
+]

--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -1,0 +1,129 @@
+from __future__ import annotations  # noqa: F401
+
+"""Skill library for managing and searching tool scripts."""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from autogpt.config import Config
+from autogpt.memory.vector.utils import get_embedding
+
+from .vector_db import Embedding, MemoryVectorDB, VectorDBProvider
+
+
+@dataclass
+class Skill:
+    """Representation of an executable tool script."""
+
+    name: str
+    code: str
+    parameters: Dict
+    description: str
+    embedding: Embedding | None = None
+
+
+class SkillLibrary:
+    """Persist and index skills for semantic search."""
+
+    def __init__(
+        self,
+        config: Config,
+        storage_path: Path | None = None,
+        vector_db: VectorDBProvider | None = None,
+    ) -> None:
+        self.config = config
+        self.storage_path = storage_path or Path("data/skills.json")
+        self.vector_db = vector_db or MemoryVectorDB()
+        self._skills: Dict[str, Skill] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.storage_path.exists():
+            return
+        with self.storage_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        for item in data:
+            skill = Skill(**item)
+            self._skills[skill.name] = skill
+            if skill.embedding is not None:
+                self.vector_db.add(
+                    skill.name,
+                    skill.embedding,
+                    {"description": skill.description, "parameters": skill.parameters},
+                )
+
+    def _save(self) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.storage_path.open("w", encoding="utf-8") as f:
+            json.dump([asdict(s) for s in self._skills.values()], f, indent=2)
+
+    # ------------------------------------------------------------------
+    def add_skill(
+        self, name: str, code: str, parameters: Dict, description: str
+    ) -> Skill:
+        """Create and persist a new skill."""
+
+        skill = Skill(name, code, parameters, description)
+        text = f"{description}\n{code}"
+        embedding = get_embedding(text, self.config)
+        skill.embedding = list(map(float, embedding))
+
+        self._skills[name] = skill
+        self.vector_db.add(
+            name,
+            skill.embedding,
+            {"description": description, "parameters": parameters},
+        )
+        self._save()
+        return skill
+
+    def get_skill(self, name: str) -> Optional[Skill]:
+        return self._skills.get(name)
+
+    def update_skill(
+        self,
+        name: str,
+        code: str | None = None,
+        parameters: Dict | None = None,
+        description: str | None = None,
+    ) -> Optional[Skill]:
+        skill = self._skills.get(name)
+        if not skill:
+            return None
+
+        if code is not None:
+            skill.code = code
+        if parameters is not None:
+            skill.parameters = parameters
+        if description is not None:
+            skill.description = description
+
+        text = f"{skill.description}\n{skill.code}"
+        embedding = get_embedding(text, self.config)
+        skill.embedding = list(map(float, embedding))
+        self.vector_db.add(
+            name,
+            skill.embedding,
+            {"description": skill.description, "parameters": skill.parameters},
+        )
+        self._save()
+        return skill
+
+    def delete_skill(self, name: str) -> None:
+        if name in self._skills:
+            del self._skills[name]
+            self.vector_db.delete(name)
+            self._save()
+
+    def list_skills(self) -> List[Skill]:
+        return list(self._skills.values())
+
+    def search(self, query: str, top_k: int = 5) -> List[Skill]:
+        """Search for skills semantically matching ``query``."""
+
+        embedding = get_embedding(query, self.config)
+        results = self.vector_db.query(list(map(float, embedding)), top_k=top_k)
+        return [self._skills[key] for key, _ in results if key in self._skills]

--- a/autogpt/skills/vector_db.py
+++ b/autogpt/skills/vector_db.py
@@ -1,0 +1,64 @@
+from __future__ import annotations  # noqa: F401
+
+"""Vector database provider abstraction for skill embeddings."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+Embedding = List[float]
+
+
+class VectorDBProvider(ABC):
+    """Abstract interface for a vector database."""
+
+    @abstractmethod
+    def add(self, key: str, embedding: Embedding, metadata: Dict | None = None) -> None:
+        """Store an embedding with optional metadata."""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Remove an embedding from the index."""
+
+    @abstractmethod
+    def query(self, embedding: Embedding, top_k: int = 5) -> List[Tuple[str, float]]:
+        """Return the ``top_k`` most similar keys to the given embedding."""
+
+    @abstractmethod
+    def get(self, key: str) -> Tuple[Embedding, Dict] | None:
+        """Return the stored embedding and metadata for ``key`` if present."""
+
+
+class MemoryVectorDB(VectorDBProvider):
+    """Simple in-memory vector database implementation."""
+
+    def __init__(self) -> None:
+        self._index: Dict[str, Tuple[Embedding, Dict]] = {}
+
+    def add(self, key: str, embedding: Embedding, metadata: Dict | None = None) -> None:
+        self._index[key] = (embedding, metadata or {})
+
+    def delete(self, key: str) -> None:
+        self._index.pop(key, None)
+
+    def query(self, embedding: Embedding, top_k: int = 5) -> List[Tuple[str, float]]:
+        if not self._index:
+            return []
+
+        query_vec = np.array(embedding)
+        results: List[Tuple[str, float]] = []
+        for key, (vec, _) in self._index.items():
+            stored_vec = np.array(vec)
+            # cosine similarity
+            score = float(
+                np.dot(query_vec, stored_vec)
+                / (np.linalg.norm(query_vec) * np.linalg.norm(stored_vec) + 1e-10)
+            )
+            results.append((key, score))
+
+        results.sort(key=lambda item: item[1], reverse=True)
+        return results[:top_k]
+
+    def get(self, key: str) -> Tuple[Embedding, Dict] | None:
+        return self._index.get(key)


### PR DESCRIPTION
## Summary
- implement pluggable vector database abstraction for skill embeddings
- add persistent skill library with semantic search and metadata storage
- expose CRUD and query helpers through `autogpt.skills`

## Testing
- `pre-commit run --files autogpt/skills/vector_db.py autogpt/skills/library.py autogpt/skills/__init__.py`
- `pytest tests/unit` *(fails: ModuleNotFoundError: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_6890f5b2566c832f914578f7a7e1dd7d