### PR TITLE
feat: add artifact cache manager

### DIFF
--- a/autogpt/cache/__init__.py
+++ b/autogpt/cache/__init__.py
@@ -1,0 +1,19 @@
+"""Cache management utilities for AutoGPT."""
+
+from .cache_manager import (
+    Artifact,
+    CacheBackend,
+    DiskCacheBackend,
+    SQLiteCacheBackend,
+    RetentionPolicy,
+    CacheManager,
+)
+
+__all__ = [
+    "Artifact",
+    "CacheBackend",
+    "DiskCacheBackend",
+    "SQLiteCacheBackend",
+    "RetentionPolicy",
+    "CacheManager",
+]

--- a/autogpt/cache/cache_manager.py
+++ b/autogpt/cache/cache_manager.py
@@ -1,0 +1,243 @@
+"""Artifact caching utilities."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import difflib
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+Embedding = List[float]
+
+
+@dataclass
+class Artifact:
+    """Representation of a stored artifact."""
+
+    task_signature: str
+    artifact_type: str
+    content: str
+    metadata: Dict[str, Any]
+    timestamp: float = field(default_factory=time.time)
+    embedding: Optional[Embedding] = None
+
+
+class CacheBackend:
+    """Abstract cache backend."""
+
+    def save(self, artifact: Artifact) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def load_all(self) -> Iterable[Artifact]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def delete(self, artifact: Artifact) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class DiskCacheBackend(CacheBackend):
+    """Persist artifacts as JSON files on disk."""
+
+    def __init__(self, storage_dir: Path) -> None:
+        self.storage_dir = storage_dir
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    # Internal -----------------------------------------------------------------
+    def _artifact_path(self, artifact: Artifact) -> Path:
+        safe_ts = int(artifact.timestamp * 1000)
+        fname = f"{safe_ts}_{artifact.artifact_type}.json"
+        return self.storage_dir / fname
+
+    # CacheBackend methods ------------------------------------------------------
+    def save(self, artifact: Artifact) -> None:
+        path = self._artifact_path(artifact)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(asdict(artifact), f, indent=2)
+
+    def load_all(self) -> Iterable[Artifact]:
+        for file in self.storage_dir.glob("*.json"):
+            with file.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            yield Artifact(**data)
+
+    def delete(self, artifact: Artifact) -> None:
+        path = self._artifact_path(artifact)
+        if path.exists():
+            path.unlink()
+
+
+class SQLiteCacheBackend(CacheBackend):
+    """Store artifacts in a SQLite database."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.conn = sqlite3.connect(db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS artifacts (
+                task_signature TEXT,
+                artifact_type TEXT,
+                content TEXT,
+                metadata TEXT,
+                timestamp REAL,
+                embedding TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def save(self, artifact: Artifact) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO artifacts VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                artifact.task_signature,
+                artifact.artifact_type,
+                artifact.content,
+                json.dumps(artifact.metadata),
+                artifact.timestamp,
+                json.dumps(artifact.embedding),
+            ),
+        )
+        self.conn.commit()
+
+    def load_all(self) -> Iterable[Artifact]:
+        cur = self.conn.cursor()
+        for row in cur.execute(
+            "SELECT task_signature, artifact_type, content, metadata, timestamp, embedding FROM artifacts"
+        ):
+            yield Artifact(
+                task_signature=row[0],
+                artifact_type=row[1],
+                content=row[2],
+                metadata=json.loads(row[3] or "{}"),
+                timestamp=row[4],
+                embedding=json.loads(row[5]) if row[5] else None,
+            )
+
+    def delete(self, artifact: Artifact) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "DELETE FROM artifacts WHERE task_signature=? AND timestamp=?",
+            (artifact.task_signature, artifact.timestamp),
+        )
+        self.conn.commit()
+
+
+@dataclass
+class RetentionPolicy:
+    """Retention policy for stored artifacts."""
+
+    max_entries: Optional[int] = None
+    max_age_seconds: Optional[int] = None
+
+
+class CacheManager:
+    """High level cache interface for storing and retrieving artifacts."""
+
+    def __init__(
+        self,
+        backend: CacheBackend,
+        retention: RetentionPolicy | None = None,
+        embedding_func: Callable[[str], Embedding] | None = None,
+    ) -> None:
+        self.backend = backend
+        self.retention = retention or RetentionPolicy()
+        self.embedding_func = embedding_func
+        # cache in memory
+        self._artifacts: List[Artifact] = list(self.backend.load_all())
+        self._prune()
+
+    # Public API ----------------------------------------------------------------
+    def store(
+        self,
+        task_signature: str,
+        artifact_type: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> Artifact:
+        embedding = (
+            self.embedding_func(task_signature) if self.embedding_func else None
+        )
+        artifact = Artifact(
+            task_signature=task_signature,
+            artifact_type=artifact_type,
+            content=content,
+            metadata=metadata,
+            embedding=embedding,
+        )
+        self.backend.save(artifact)
+        self._artifacts.append(artifact)
+        self._prune()
+        return artifact
+
+    def lookup_by_signature(self, task_signature: str) -> List[Artifact]:
+        """Return all artifacts matching ``task_signature``."""
+
+        return [a for a in self._artifacts if a.task_signature == task_signature]
+
+    def lookup_by_similarity(self, query: str, top_k: int = 5) -> List[Artifact]:
+        """Return artifacts most similar to ``query``."""
+
+        results: List[Tuple[float, Artifact]] = []
+        if self.embedding_func:
+            q_emb = self.embedding_func(query)
+        else:
+            q_emb = None
+
+        for art in self._artifacts:
+            if q_emb is not None and art.embedding is not None:
+                score = self._cosine_sim(q_emb, art.embedding)
+            else:
+                score = difflib.SequenceMatcher(None, query, art.task_signature).ratio()
+            results.append((score, art))
+
+        results.sort(key=lambda x: x[0], reverse=True)
+        return [a for _, a in results[:top_k]]
+
+    # Internal -----------------------------------------------------------------
+    def _prune(self) -> None:
+        """Apply retention policy."""
+
+        if self.retention.max_entries is None and self.retention.max_age_seconds is None:
+            return
+
+        now = time.time()
+        # Remove old entries by age
+        if self.retention.max_age_seconds is not None:
+            cutoff = now - self.retention.max_age_seconds
+            remaining: List[Artifact] = []
+            for art in sorted(self._artifacts, key=lambda a: a.timestamp):
+                if art.timestamp >= cutoff:
+                    remaining.append(art)
+                else:
+                    self.backend.delete(art)
+            self._artifacts = remaining
+
+        # Remove extra entries by count
+        if (
+            self.retention.max_entries is not None
+            and len(self._artifacts) > self.retention.max_entries
+        ):
+            # Remove oldest
+            self._artifacts.sort(key=lambda a: a.timestamp, reverse=True)
+            for art in self._artifacts[self.retention.max_entries :]:
+                self.backend.delete(art)
+            self._artifacts = self._artifacts[: self.retention.max_entries]
+
+    @staticmethod
+    def _cosine_sim(a: Embedding, b: Embedding) -> float:
+        import math
+
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(x * x for x in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from autogpt.cache.cache_manager import (
+    CacheManager,
+    DiskCacheBackend,
+    SQLiteCacheBackend,
+    RetentionPolicy,
+)
+
+
+def dummy_embedder(text: str):
+    """Deterministic embedding for tests."""
+
+    import hashlib
+
+    h = hashlib.md5(text.encode("utf-8")).digest()
+    return [float(b) for b in h[:8]]
+
+
+def test_store_and_lookup_by_signature(tmp_path: Path):
+    backend = DiskCacheBackend(tmp_path)
+    manager = CacheManager(backend, embedding_func=dummy_embedder)
+    manager.store("task1", "log", "content", {"foo": "bar"})
+    results = manager.lookup_by_signature("task1")
+    assert len(results) == 1
+    assert results[0].content == "content"
+
+
+def test_lookup_by_similarity(tmp_path: Path):
+    backend = DiskCacheBackend(tmp_path)
+    manager = CacheManager(backend, embedding_func=dummy_embedder)
+    manager.store("write unit tests", "script", "...", {})
+    manager.store("generate documentation", "script", "...", {})
+    results = manager.lookup_by_similarity("unit tests", top_k=1)
+    assert results[0].task_signature == "write unit tests"
+
+
+def test_retention_policy_by_count(tmp_path: Path):
+    backend = DiskCacheBackend(tmp_path)
+    policy = RetentionPolicy(max_entries=1)
+    manager = CacheManager(backend, retention=policy)
+    manager.store("task1", "log", "a", {})
+    manager.store("task2", "log", "b", {})
+    assert not manager.lookup_by_signature("task1")
+    assert manager.lookup_by_signature("task2")
+
+
+def test_sqlite_backend(tmp_path: Path):
+    db_path = tmp_path / "cache.db"
+    backend = SQLiteCacheBackend(db_path)
+    manager = CacheManager(backend)
+    manager.store("task1", "log", "a", {})
+    assert manager.lookup_by_signature("task1")


### PR DESCRIPTION
## Summary
- add cache manager for storing artifacts with configurable disk and SQLite backends
- support lookup by task signature or semantic similarity
- include retention policies and unit tests for cache manager

## Testing
- `ruff check autogpt/cache/cache_manager.py tests/unit/test_cache_manager.py`
- `python - <<'PY'
from pathlib import Path
import tempfile
from tests.unit.test_cache_manager import (
    test_store_and_lookup_by_signature,
    test_lookup_by_similarity,
    test_retention_policy_by_count,
    test_sqlite_backend,
)
with tempfile.TemporaryDirectory() as d:
    tmp = Path(d)
    test_store_and_lookup_by_signature(tmp)
    test_lookup_by_similarity(tmp)
    test_retention_policy_by_count(tmp)
    test_sqlite_backend(tmp)
print('all tests passed')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890fc44ee44832fac3a094bc2f358b3