### PR TITLE
feat: add live dashboard

### DIFF
--- a/autogpt/dashboard/README.md
+++ b/autogpt/dashboard/README.md
@@ -1,0 +1,23 @@
+# AutoGPT Dashboard
+
+This simple Flask application subscribes to the shared `MessageQueue` and
+presents a live view of issue‑related events.
+
+## Running
+
+```bash
+python -m autogpt.dashboard.app
+```
+
+The dashboard listens on `http://localhost:8000/` by default. If the environment
+variable `DASHBOARD_TOKEN` is set (or a token is passed to `run_dashboard`), the
+same value must be supplied as a query parameter or `X-Dashboard-Token` header
+when accessing the dashboard.
+
+## Features
+
+- Streams events such as `ISSUE_DETECTED`, `DIAGNOSIS_COMPLETE`,
+  `CODE_FIX_PROPOSED`, `HUMAN_APPROVAL_REQUIRED`, and `ISSUE_RESOLVED`.
+- Displays the latest state, timestamp, and source agent information for each
+  issue.
+- Exposes an `/issues` endpoint with the aggregated per‑issue state.

--- a/autogpt/dashboard/__init__.py
+++ b/autogpt/dashboard/__init__.py
@@ -1,0 +1,4 @@
+"""AutoGPT event dashboard."""
+from .app import create_dashboard_app, run_dashboard
+
+__all__ = ["create_dashboard_app", "run_dashboard"]

--- a/autogpt/dashboard/app.py
+++ b/autogpt/dashboard/app.py
@@ -1,0 +1,136 @@
+"""Dashboard web app displaying live events from the MessageQueue."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from queue import Queue
+from threading import Lock
+from typing import Any, Dict, Iterable
+
+from flask import Flask, Response, abort, render_template, request
+
+from autogpt.event_bus import (
+    CODE_FIX_PROPOSED,
+    DIAGNOSIS_COMPLETE,
+    HUMAN_APPROVAL_REQUIRED,
+    ISSUE_RESOLVED,
+    EventMessage,
+    MessageQueue,
+)
+
+EVENT_TYPES = [
+    "ISSUE_DETECTED",
+    DIAGNOSIS_COMPLETE,
+    CODE_FIX_PROPOSED,
+    HUMAN_APPROVAL_REQUIRED,
+    ISSUE_RESOLVED,
+]
+
+
+def create_dashboard_app(
+    message_queue: MessageQueue | None = None,
+    *,
+    auth_token: str | None = None,
+) -> Flask:
+    """Create a Flask app that serves a live event dashboard.
+
+    Parameters
+    ----------
+    message_queue:
+        Queue to subscribe to. If ``None`` a new queue will be created.
+    auth_token:
+        Optional token required in query parameter ``token`` or header
+        ``X-Dashboard-Token`` to access endpoints.
+    """
+
+    app = Flask(__name__, template_folder=str(Path(__file__).with_name("templates")))
+    mq = message_queue or MessageQueue()
+    subscribers: list[Queue] = []
+    issues: Dict[str, Dict[str, Any]] = {}
+    lock = Lock()
+
+    def _authorized() -> bool:
+        token = auth_token or os.getenv("DASHBOARD_TOKEN")
+        if not token:
+            return True
+        supplied = request.args.get("token") or request.headers.get(
+            "X-Dashboard-Token"
+        )
+        return supplied == token
+
+    def _issue_id(event: EventMessage) -> str:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        return (
+            str(payload.get("issue_id")
+                or payload.get("branch_name")
+                or "unknown")
+        )
+
+    def _broadcast(event: EventMessage) -> None:
+        data = {
+            "event_type": event.event_type,
+            "payload": event.payload,
+            "source_agent": event.source_agent,
+            "timestamp": event.timestamp,
+            "issue_id": _issue_id(event),
+        }
+        with lock:
+            issues.setdefault(data["issue_id"], {"events": []})["events"].append(data)
+            issues[data["issue_id"]].update(data)
+        for q in list(subscribers):
+            q.put(data)
+
+    for event_type in EVENT_TYPES:
+        mq.subscribe(event_type, _broadcast)
+
+    @app.route("/")
+    def index() -> str:
+        if not _authorized():
+            abort(401)
+        return render_template("index.html")
+
+    @app.route("/stream")
+    def stream() -> Response:
+        if not _authorized():
+            abort(401)
+        q: Queue = Queue()
+        subscribers.append(q)
+
+        def gen() -> Iterable[str]:
+            try:
+                while True:
+                    data = q.get()
+                    yield f"data: {json.dumps(data)}\n\n"
+            except GeneratorExit:
+                subscribers.remove(q)
+
+        return Response(gen(), mimetype="text/event-stream")
+
+    @app.route("/issues")
+    def get_issues() -> Any:
+        if not _authorized():
+            abort(401)
+        with lock:
+            return {k: v for k, v in issues.items()}
+
+    return app
+
+
+def run_dashboard(
+    message_queue: MessageQueue | None = None,
+    *,
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    auth_token: str | None = None,
+) -> None:
+    """Run the dashboard web server."""
+
+    app = create_dashboard_app(message_queue, auth_token=auth_token)
+    app.run(host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    run_dashboard()
+

--- a/autogpt/dashboard/templates/index.html
+++ b/autogpt/dashboard/templates/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>AutoGPT Event Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; }
+        th { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>AutoGPT Event Dashboard</h1>
+    <h2>Issues</h2>
+    <table id="issues">
+        <thead>
+            <tr><th>Issue</th><th>State</th><th>Source Agent</th><th>Timestamp</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <h2>Event Log</h2>
+    <ul id="log"></ul>
+<script>
+const token = new URLSearchParams(window.location.search).get('token');
+const evtSource = new EventSource('/stream' + (token ? '?token='+token : ''));
+const issues = {};
+
+evtSource.onmessage = (e) => {
+    const data = JSON.parse(e.data);
+    const log = document.getElementById('log');
+    const item = document.createElement('li');
+    item.textContent = `${data.timestamp} [${data.event_type}] from ${data.source_agent} (${data.issue_id})`;
+    log.appendChild(item);
+    issues[data.issue_id] = data;
+    renderIssues();
+};
+
+function renderIssues() {
+    const tbody = document.querySelector('#issues tbody');
+    tbody.innerHTML = '';
+    Object.values(issues).forEach(issue => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${issue.issue_id}</td><td>${issue.event_type}</td><td>${issue.source_agent}</td><td>${issue.timestamp}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+</script>
+</body>
+</html>

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from autogpt.dashboard import create_dashboard_app
+from autogpt.event_bus import EventMessage, MessageQueue
+
+
+def test_dashboard_tracks_events() -> None:
+    mq = MessageQueue()
+    app = create_dashboard_app(mq)
+    client = app.test_client()
+
+    event = EventMessage(
+        event_type="ISSUE_DETECTED",
+        payload={"issue_id": "42"},
+        source_agent="tester",
+    )
+    mq.publish(event)
+
+    resp = client.get("/issues")
+    data = resp.get_json()
+    assert data["42"]["event_type"] == "ISSUE_DETECTED"
+    assert data["42"]["source_agent"] == "tester"
+    assert data["42"]["timestamp"] == event.timestamp
+
+
+def test_auth_token_required() -> None:
+    mq = MessageQueue()
+    app = create_dashboard_app(mq, auth_token="secret")
+    client = app.test_client()
+
+    assert client.get("/").status_code == 401
+    assert client.get("/?token=secret").status_code == 200


### PR DESCRIPTION
## Summary
- add Flask dashboard streaming MessageQueue events per issue with auth token gate
- track issue state and render live log via SSE
- document usage and add unit tests for event tracking and access control

## Testing
- `ruff check autogpt/dashboard tests/unit/test_dashboard.py`
- `pytest tests/unit/test_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6891351f0de8832fb585b410f72c7930