### PR TITLE
Add orchestrator and dashboard regression tests

### DIFF
--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import json
+
 from autogpt.dashboard import create_dashboard_app
-from autogpt.event_bus import EventMessage, MessageQueue
+from autogpt.event_bus import (
+    DIAGNOSIS_COMPLETE,
+    ISSUE_RESOLVED,
+    EventMessage,
+    MessageQueue,
+)
 
 
 def test_dashboard_tracks_events() -> None:
@@ -30,3 +37,74 @@ def test_auth_token_required() -> None:
 
     assert client.get("/").status_code == 401
     assert client.get("/?token=secret").status_code == 200
+
+
+def test_dashboard_streams_events_and_updates_state() -> None:
+    mq = MessageQueue()
+    app = create_dashboard_app(mq)
+
+    with app.test_request_context("/stream"):
+        resp = app.view_functions["stream"]()
+        gen = resp.response
+
+        events = [
+            EventMessage(
+                event_type="ISSUE_DETECTED",
+                payload={"issue_id": "1"},
+                source_agent="tester",
+            ),
+            EventMessage(
+                event_type=DIAGNOSIS_COMPLETE,
+                payload={"issue_id": "1"},
+                source_agent="diag",
+            ),
+            EventMessage(
+                event_type=ISSUE_RESOLVED,
+                payload={"issue_id": "1"},
+                source_agent="tester",
+            ),
+        ]
+
+        for event in events:
+            mq.publish(event)
+            data = next(gen)
+            payload = json.loads(data.split("data: ")[1])
+            assert payload["event_type"] == event.event_type
+
+    client = app.test_client()
+    resp = client.get("/issues")
+    issue = resp.get_json()["1"]
+    assert issue["event_type"] == ISSUE_RESOLVED
+    assert len(issue["events"]) == len(events)
+
+
+def test_dashboard_handles_missing_issue_id() -> None:
+    mq = MessageQueue()
+    app = create_dashboard_app(mq)
+    client = app.test_client()
+
+    event = EventMessage(event_type="ISSUE_DETECTED", payload={}, source_agent="tester")
+    mq.publish(event)
+
+    resp = client.get("/issues")
+    data = resp.get_json()
+    assert "unknown" in data
+
+
+def test_stream_removes_disconnected_clients() -> None:
+    mq = MessageQueue()
+    app = create_dashboard_app(mq)
+    stream_func = app.view_functions["stream"]
+    subscribers = next(
+        cell.cell_contents for cell in stream_func.__closure__ if isinstance(cell.cell_contents, list)
+    )
+
+    assert len(subscribers) == 0
+    with app.test_request_context("/stream"):
+        resp = stream_func()
+        gen = resp.response
+        assert len(subscribers) == 1
+        mq.publish(EventMessage(event_type="ISSUE_DETECTED", payload={}, source_agent="tester"))
+        next(gen)
+        gen.close()
+        assert len(subscribers) == 0

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import threading
+
+import autogpt.orchestrator as orch_mod
+from autogpt.event_bus import EventMessage
+from autogpt.orchestrator import Orchestrator
+
+
+def test_orchestrator_process_lifecycle(monkeypatch):
+    orc = Orchestrator()
+
+    events: list[EventMessage] = []
+
+    def fake_publish(event: EventMessage) -> None:
+        events.append(event)
+
+    orc.message_queue.publish = fake_publish  # type: ignore[assignment]
+
+    def make_run(name: str):
+        def _run(self: Orchestrator) -> None:
+            self.message_queue.publish(
+                EventMessage(event_type="TEST", payload={"agent": name}, source_agent=name)
+            )
+        return _run
+
+    monkeypatch.setattr(Orchestrator, "_run_archaeologist", make_run("archaeologist"))
+    monkeypatch.setattr(Orchestrator, "_run_tdd_developer", make_run("tdd_developer"))
+    monkeypatch.setattr(Orchestrator, "_run_qa_agent", make_run("qa_agent"))
+
+    orc.start_agents()
+    assert set(orc.threads.keys()) == {"archaeologist", "tdd_developer", "qa_agent"}
+    for thread, _ in orc.threads.values():
+        thread.join(timeout=0.1)
+
+    orc.stop()
+
+    assert [e.payload["agent"] for e in events] == ["archaeologist", "tdd_developer", "qa_agent"]
+
+
+def test_orchestrator_restarts_dead_threads(monkeypatch):
+    orc = Orchestrator()
+
+    started: list[str] = []
+
+    def fake_start_thread(self, name: str, target):
+        started.append(name)
+        thread = threading.Thread(target=target, name=name)
+        thread.start()
+        orc.threads[name] = (thread, target)
+
+    monkeypatch.setattr(Orchestrator, "_start_thread", fake_start_thread)
+
+    def fast_run(self: Orchestrator) -> None:
+        return
+
+    monkeypatch.setattr(Orchestrator, "_run_archaeologist", fast_run)
+    monkeypatch.setattr(Orchestrator, "_run_tdd_developer", fast_run)
+    monkeypatch.setattr(Orchestrator, "_run_qa_agent", fast_run)
+
+    orc.start_agents()
+    assert started == ["archaeologist", "tdd_developer", "qa_agent"]
+
+    calls: list[str] = []
+
+    def fake_restart(self, name: str, target):
+        calls.append(name)
+        thread = threading.Thread(target=target, name=name)
+        thread.start()
+        orc.threads[name] = (thread, target)
+
+    monkeypatch.setattr(Orchestrator, "_start_thread", fake_restart)
+
+    def fake_sleep(_):
+        orc.stop_event.set()
+
+    monkeypatch.setattr(orch_mod.time, "sleep", fake_sleep)
+
+    orc.monitor()
+    assert calls == ["archaeologist", "tdd_developer", "qa_agent"]


### PR DESCRIPTION
## Summary
- extend dashboard tests to cover streaming, state transitions, missing event IDs and client disconnects
- add orchestrator lifecycle tests for clean start/stop and thread restart logic

## Testing
- `pytest tests/unit/test_orchestrator.py tests/unit/test_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68914f5ccef8832f8e8c0f679ac764ac