### PR TITLE
docs: add orchestrator and dashboard guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ queue.subscribe("example", handler)
 queue.publish(EventMessage(event_type="example", payload={"foo": "bar"}, source_agent="demo"))
 ```
 
+## 编排器与仪表盘
+
+仓库包含一个简易的编排器，用于启动并监督这些事件驱动的代理：
+
+```bash
+python scripts/run_orchestrator.py
+```
+
+同时可以启动仪表盘以实时查看问题生命周期中的事件：
+
+```bash
+python -m autogpt.dashboard.app
+```
+
+仪表盘默认监听 `http://localhost:8000/`。若设置环境变量 `DASHBOARD_TOKEN`，访问时需在查询参数或 `X-Dashboard-Token` 请求头中提供相同的令牌。
+
 ## 运行应用
 
 ```bash

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -1,5 +1,24 @@
 # Agents
 
+## Master Orchestrator and Issue Lifecycle
+
+Auto‑GPT ships with a lightweight orchestrator that coordinates the helper
+agents over the shared event bus. It supervises the lifecycle of an issue from
+detection to resolution:
+
+1. **Detection** – A component emits `ISSUE_DETECTED` when a problem occurs.
+2. **Diagnosis** – `ArchaeologistAgent` analyses the repository and publishes
+   `DIAGNOSIS_COMPLETE`.
+3. **Development** – `TDDDeveloperAgent` creates a regression test, guides the
+   fix and reports `CODE_FIX_PROPOSED`.
+4. **Quality assurance** – `QAAgent` runs the test suite and requests manual
+   review via `HUMAN_APPROVAL_REQUIRED`.
+5. **Resolution** – After approval, the fix is merged and `ISSUE_RESOLVED`
+   finalises the cycle.
+
+The orchestrator ensures each agent is running and relays events between them,
+providing a full end‑to‑end workflow for addressing issues.
+
 ## ArchaeologistAgent
 
 `ArchaeologistAgent` is an event‑driven diagnostic helper that assists plugin

--- a/docs/architecture/dashboard.md
+++ b/docs/architecture/dashboard.md
@@ -1,0 +1,25 @@
+# Dashboard
+
+The Auto‑GPT dashboard provides a live view of issue events emitted on the
+shared message queue. It is useful for tracking the orchestrated issue lifecycle.
+
+## Setup
+
+Install dependencies and start the web server:
+
+```bash
+python -m autogpt.dashboard.app
+```
+
+The server listens on `http://localhost:8000/` by default.
+
+## Configuration
+
+- **Authentication** – Set the environment variable `DASHBOARD_TOKEN` to require
+  a matching token as a query parameter or `X-Dashboard-Token` header.
+- **Message queue** – The dashboard subscribes to the same `MessageQueue` used by
+  the agents.
+
+## Screenshots
+
+![Dashboard](../imgs/e2b-dashboard.png)


### PR DESCRIPTION
## Summary
- outline orchestrator role and issue lifecycle in architecture docs
- document dashboard setup and configuration with screenshot reference
- mention orchestrator entry point and dashboard access in README

## Testing
- `pre-commit run --files docs/architecture/agents.md docs/architecture/dashboard.md README.md` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6891866b1678832f9dd73b95c0b8f800