### PR TITLE
refactor: persist skills in dedicated folders

### DIFF
--- a/autogpt/skills/__init__.py
+++ b/autogpt/skills/__init__.py
@@ -23,33 +23,36 @@ def get_library() -> SkillLibrary:
     return _default_library
 
 
-def add(name: str, code: str, parameters: Dict, description: str) -> Skill:
+def add(
+    name: str, version: str, code: str, parameters: Dict, description: str
+) -> Skill:
     """Add a new skill to the library."""
 
-    return get_library().add_skill(name, code, parameters, description)
+    return get_library().add_skill(name, version, code, parameters, description)
 
 
-def get(name: str) -> Optional[Skill]:
-    """Return a skill by name if it exists."""
+def get(name: str, version: str) -> Optional[Skill]:
+    """Return a skill by name/version if it exists."""
 
-    return get_library().get_skill(name)
+    return get_library().get_skill(name, version)
 
 
 def update(
     name: str,
+    version: str,
     code: str | None = None,
     parameters: Dict | None = None,
     description: str | None = None,
 ) -> Optional[Skill]:
     """Update an existing skill."""
 
-    return get_library().update_skill(name, code, parameters, description)
+    return get_library().update_skill(name, version, code, parameters, description)
 
 
-def delete(name: str) -> None:
+def delete(name: str, version: str) -> None:
     """Remove a skill from the library."""
 
-    get_library().delete_skill(name)
+    get_library().delete_skill(name, version)
 
 
 def list_skills() -> List[Skill]:

--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -3,7 +3,9 @@ from __future__ import annotations  # noqa: F401
 """Skill library for managing and searching tool scripts."""
 
 import json
-from dataclasses import asdict, dataclass
+import shutil
+import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -18,6 +20,7 @@ class Skill:
     """Representation of an executable tool script."""
 
     name: str
+    version: str
     code: str
     parameters: Dict
     description: str
@@ -34,7 +37,7 @@ class SkillLibrary:
         vector_db: VectorDBProvider | None = None,
     ) -> None:
         self.config = config
-        self.storage_path = storage_path or Path("data/skills.json")
+        self.storage_path = storage_path or Path("skill_library")
         self.vector_db = vector_db or MemoryVectorDB()
         self._skills: Dict[str, Skill] = {}
         self._load()
@@ -43,54 +46,98 @@ class SkillLibrary:
     def _load(self) -> None:
         if not self.storage_path.exists():
             return
-        with self.storage_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        for item in data:
-            skill = Skill(**item)
-            self._skills[skill.name] = skill
+        for skill_dir in self.storage_path.iterdir():
+            if not skill_dir.is_dir():
+                continue
+            meta_file = skill_dir / "skill.json"
+            code_file = skill_dir / "main.py"
+            if not meta_file.exists() or not code_file.exists():
+                continue
+            with meta_file.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            with code_file.open("r", encoding="utf-8") as f:
+                code = f.read()
+            skill = Skill(code=code, **data)
+            key = f"{skill.name}_{skill.version}"
+            self._skills[key] = skill
             if skill.embedding is not None:
                 self.vector_db.add(
-                    skill.name,
+                    key,
                     skill.embedding,
                     {"description": skill.description, "parameters": skill.parameters},
                 )
 
-    def _save(self) -> None:
-        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
-        with self.storage_path.open("w", encoding="utf-8") as f:
-            json.dump([asdict(s) for s in self._skills.values()], f, indent=2)
+    def _skill_dir(self, name: str, version: str) -> Path:
+        return self.storage_path / f"{name}_{version}"
+
+    def _write_skill(self, skill: Skill) -> Path:
+        skill_dir = self._skill_dir(skill.name, skill.version)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "main.py").write_text(skill.code, encoding="utf-8")
+        (skill_dir / "test_main.py").touch()
+        (skill_dir / "requirements.txt").touch()
+        with (skill_dir / "skill.json").open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "name": skill.name,
+                    "version": skill.version,
+                    "parameters": skill.parameters,
+                    "description": skill.description,
+                    "embedding": skill.embedding,
+                },
+                f,
+                indent=2,
+            )
+        return skill_dir
+
+    def _git_commit(self, path: Path, message: str) -> None:
+        repo = path.resolve()
+        while repo != repo.parent and not (repo / ".git").exists():
+            repo = repo.parent
+        if not (repo / ".git").exists():
+            return
+        rel = path.resolve().relative_to(repo)
+        try:
+            subprocess.run(["git", "add", str(rel)], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-m", message], cwd=repo, check=False)
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     def add_skill(
-        self, name: str, code: str, parameters: Dict, description: str
+        self, name: str, version: str, code: str, parameters: Dict, description: str
     ) -> Skill:
         """Create and persist a new skill."""
 
-        skill = Skill(name, code, parameters, description)
+        skill = Skill(name, version, code, parameters, description)
         text = f"{description}\n{code}"
         embedding = get_embedding(text, self.config)
         skill.embedding = list(map(float, embedding))
 
-        self._skills[name] = skill
+        key = f"{name}_{version}"
+        self._skills[key] = skill
         self.vector_db.add(
-            name,
+            key,
             skill.embedding,
             {"description": description, "parameters": parameters},
         )
-        self._save()
+        skill_dir = self._write_skill(skill)
+        self._git_commit(skill_dir, f"Add skill {name} {version}")
         return skill
 
-    def get_skill(self, name: str) -> Optional[Skill]:
-        return self._skills.get(name)
+    def get_skill(self, name: str, version: str) -> Optional[Skill]:
+        return self._skills.get(f"{name}_{version}")
 
     def update_skill(
         self,
         name: str,
+        version: str,
         code: str | None = None,
         parameters: Dict | None = None,
         description: str | None = None,
     ) -> Optional[Skill]:
-        skill = self._skills.get(name)
+        key = f"{name}_{version}"
+        skill = self._skills.get(key)
         if not skill:
             return None
 
@@ -105,18 +152,23 @@ class SkillLibrary:
         embedding = get_embedding(text, self.config)
         skill.embedding = list(map(float, embedding))
         self.vector_db.add(
-            name,
+            key,
             skill.embedding,
             {"description": skill.description, "parameters": skill.parameters},
         )
-        self._save()
+        skill_dir = self._write_skill(skill)
+        self._git_commit(skill_dir, f"Update skill {name} {version}")
         return skill
 
-    def delete_skill(self, name: str) -> None:
-        if name in self._skills:
-            del self._skills[name]
-            self.vector_db.delete(name)
-            self._save()
+    def delete_skill(self, name: str, version: str) -> None:
+        key = f"{name}_{version}"
+        if key in self._skills:
+            del self._skills[key]
+            self.vector_db.delete(key)
+            skill_dir = self._skill_dir(name, version)
+            if skill_dir.exists():
+                shutil.rmtree(skill_dir)
+                self._git_commit(skill_dir, f"Delete skill {name} {version}")
 
     def list_skills(self) -> List[Skill]:
         return list(self._skills.values())

--- a/tests/unit/test_skill_library.py
+++ b/tests/unit/test_skill_library.py
@@ -1,5 +1,4 @@
 """Tests for :mod:`autogpt.skills.library`."""
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -19,7 +18,9 @@ def make_embedding_map() -> Dict[str, List[float]]:
     }
 
 
-def test_skill_library_save_and_search(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_skill_library_save_and_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     import sys
     from types import ModuleType
 
@@ -33,7 +34,7 @@ def test_skill_library_save_and_search(tmp_path: Path, monkeypatch: pytest.Monke
     from autogpt.skills.vector_db import MemoryVectorDB
 
     config = Config()
-    storage = tmp_path / "skills.json"
+    storage = tmp_path / "skill_library"
     vector_db = MemoryVectorDB()
 
     embeddings = make_embedding_map()
@@ -41,22 +42,20 @@ def test_skill_library_save_and_search(tmp_path: Path, monkeypatch: pytest.Monke
     def fake_get_embedding(text: str, _config: Config) -> List[float]:
         return embeddings[text]
 
-    monkeypatch.setattr(
-        "autogpt.skills.library.get_embedding", fake_get_embedding
-    )
+    monkeypatch.setattr("autogpt.skills.library.get_embedding", fake_get_embedding)
 
     library = SkillLibrary(config, storage_path=storage, vector_db=vector_db)
 
-    library.add_skill("skill1", "code1", {"a": 1}, "description1")
-    library.add_skill("skill2", "code2", {"b": 2}, "description2")
+    library.add_skill("skill1", "1.0", "code1", {"a": 1}, "description1")
+    library.add_skill("skill2", "1.0", "code2", {"b": 2}, "description2")
 
     # Ensure skills are persisted and retrievable
     assert storage.exists()
-    assert library.get_skill("skill1")
+    assert (storage / "skill1_1.0" / "main.py").exists()
+    assert library.get_skill("skill1", "1.0")
 
     # Reload from disk to verify save/load cycle
     new_library = SkillLibrary(config, storage_path=storage, vector_db=MemoryVectorDB())
 
     results = new_library.search("description1", top_k=1)
     assert results and results[0].name == "skill1"
-


### PR DESCRIPTION
## Summary
- store skills as individual `skill_library/<name>_<version>` folders with code and metadata
- update `SkillLibrary` API to manage versioned skills and commit new folders via git
- adjust tests for new directory-based skill storage

## Testing
- `mypy autogpt/skills/library.py autogpt/skills/__init__.py`
- `pytest tests/unit/test_skill_library.py -q` *(fails: No module named 'ftfy')*


------
https://chatgpt.com/codex/tasks/task_e_68918a6d6614832fa68730436037c7ee