### PR TITLE
feat: add librarian agent for skill management

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Agent wrapper around :class:`SkillLibrary` for managing skills."""
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import List
+
+from autogpt.config import Config
+
+from .library import SkillLibrary, SkillMetadata
+
+
+class LibrarianAgent:
+    """High level interface for managing the skill library."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.skill_library = SkillLibrary(config or Config())
+
+    # ------------------------------------------------------------------
+    def find_skill(self, query: str, top_k: int = 3) -> List[dict]:
+        """Search for skills matching ``query`` and return their metadata."""
+
+        skills = self.skill_library.search(query, top_k=top_k)
+        return [asdict(skill.metadata) for skill in skills]
+
+    # ------------------------------------------------------------------
+    def add_skill(self, skill_metadata: dict, skill_code_path: str) -> bool:
+        """Add a new skill to the library.
+
+        Parameters
+        ----------
+        skill_metadata: dict
+            Metadata describing the skill. Must conform to :class:`SkillMetadata`.
+        skill_code_path: str
+            Path to the Python file containing the skill's code.
+        """
+
+        try:
+            metadata = SkillMetadata(**skill_metadata)
+        except TypeError:
+            return False
+
+        try:
+            code = Path(skill_code_path).read_text(encoding="utf-8")
+        except OSError:
+            return False
+
+        try:
+            self.skill_library.add_skill(
+                name=metadata.skill_name,
+                version=metadata.version,
+                code=code,
+                parameters=metadata.parameters,
+                description=metadata.description,
+                tags=metadata.tags,
+            )
+            return True
+        except Exception:
+            return False

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -1,0 +1,47 @@
+"""CLI for interacting with the :class:`LibrarianAgent`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from autogpt.config import Config
+from autogpt.skills.librarian import LibrarianAgent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with the librarian agent")
+    sub = parser.add_subparsers(dest="command")
+
+    find_p = sub.add_parser("find", help="Search for skills")
+    find_p.add_argument("query", help="Search query")
+    find_p.add_argument("--k", type=int, default=3, help="Number of results to return")
+
+    add_p = sub.add_parser("add", help="Add a new skill")
+    add_p.add_argument("metadata", help="Path to JSON metadata file")
+    add_p.add_argument("code", help="Path to Python file containing the skill")
+
+    args = parser.parse_args()
+    agent = LibrarianAgent(Config())
+
+    if args.command == "find":
+        results = agent.find_skill(args.query, args.k)
+        if not results:
+            print("No matching skills found")
+        else:
+            for meta in results:
+                print(json.dumps(meta, indent=2))
+    elif args.command == "add":
+        with Path(args.metadata).open("r", encoding="utf-8") as f:
+            metadata = json.load(f)
+        if agent.add_skill(metadata, args.code):
+            print("Skill added successfully")
+        else:
+            print("Failed to add skill")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LibrarianAgent wrapping SkillLibrary for skill lookup and registration
- provide CLI interface for searching and adding skills via LibrarianAgent

## Testing
- `pytest tests/unit/test_skill_library.py tests/unit/test_skill_repository.py`

------
https://chatgpt.com/codex/tasks/task_e_68919dbfa2f4832fb52eed8bccf99a2b