### PR TITLE
feat: extend skill metadata

### DIFF
--- a/autogpt/skills/__init__.py
+++ b/autogpt/skills/__init__.py
@@ -30,10 +30,27 @@ def add(
     parameters: Dict,
     description: str,
     tags: List[str],
+    dependencies_file: str | None = None,
+    entry_point: str | None = None,
+    return_type: str | None = None,
+    author_agent: str | None = None,
+    creation_timestamp: str | None = None,
 ) -> Skill:
     """Add a new skill to the library."""
 
-    return get_library().add_skill(name, version, code, parameters, description, tags)
+    return get_library().add_skill(
+        name,
+        version,
+        code,
+        parameters,
+        description,
+        tags,
+        dependencies_file,
+        entry_point,
+        return_type,
+        author_agent,
+        creation_timestamp,
+    )
 
 
 def get(name: str, version: str) -> Optional[Skill]:
@@ -49,10 +66,27 @@ def update(
     parameters: Dict | None = None,
     description: str | None = None,
     tags: List[str] | None = None,
+    dependencies_file: str | None = None,
+    entry_point: str | None = None,
+    return_type: str | None = None,
+    author_agent: str | None = None,
+    creation_timestamp: str | None = None,
 ) -> Optional[Skill]:
     """Update an existing skill."""
 
-    return get_library().update_skill(name, version, code, parameters, description, tags)
+    return get_library().update_skill(
+        name,
+        version,
+        code,
+        parameters,
+        description,
+        tags,
+        dependencies_file,
+        entry_point,
+        return_type,
+        author_agent,
+        creation_timestamp,
+    )
 
 
 def delete(name: str, version: str) -> None:

--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -24,6 +24,11 @@ class SkillMetadata:
     description: str
     tags: List[str]
     parameters: Dict
+    dependencies_file: str | None = None
+    entry_point: str | None = None
+    return_type: str | None = None
+    author_agent: str | None = None
+    creation_timestamp: str | None = None
 
 
 @dataclass
@@ -134,6 +139,11 @@ class SkillLibrary:
                     "description": skill.description,
                     "tags": skill.tags,
                     "parameters": skill.parameters,
+                    "dependencies_file": skill.metadata.dependencies_file,
+                    "entry_point": skill.metadata.entry_point,
+                    "return_type": skill.metadata.return_type,
+                    "author_agent": skill.metadata.author_agent,
+                    "creation_timestamp": skill.metadata.creation_timestamp,
                 },
                 f,
                 indent=2,
@@ -162,10 +172,26 @@ class SkillLibrary:
         parameters: Dict,
         description: str,
         tags: List[str],
+        dependencies_file: str | None = None,
+        entry_point: str | None = None,
+        return_type: str | None = None,
+        author_agent: str | None = None,
+        creation_timestamp: str | None = None,
     ) -> Skill:
         """Create and persist a new skill."""
 
-        metadata = SkillMetadata(name, version, description, tags, parameters)
+        metadata = SkillMetadata(
+            name,
+            version,
+            description,
+            tags,
+            parameters,
+            dependencies_file,
+            entry_point,
+            return_type,
+            author_agent,
+            creation_timestamp,
+        )
         skill = Skill(metadata=metadata, code=code)
         text = f"{description}\n{' '.join(tags)}"
         embedding = get_embedding(text, self.config)
@@ -193,6 +219,11 @@ class SkillLibrary:
         parameters: Dict | None = None,
         description: str | None = None,
         tags: List[str] | None = None,
+        dependencies_file: str | None = None,
+        entry_point: str | None = None,
+        return_type: str | None = None,
+        author_agent: str | None = None,
+        creation_timestamp: str | None = None,
     ) -> Optional[Skill]:
         key = f"{name}_{version}"
         skill = self._skills.get(key)
@@ -207,6 +238,16 @@ class SkillLibrary:
             skill.metadata.description = description
         if tags is not None:
             skill.metadata.tags = tags
+        if dependencies_file is not None:
+            skill.metadata.dependencies_file = dependencies_file
+        if entry_point is not None:
+            skill.metadata.entry_point = entry_point
+        if return_type is not None:
+            skill.metadata.return_type = return_type
+        if author_agent is not None:
+            skill.metadata.author_agent = author_agent
+        if creation_timestamp is not None:
+            skill.metadata.creation_timestamp = creation_timestamp
 
         text = f"{skill.description}\n{' '.join(skill.tags)}"
         embedding = get_embedding(text, self.config)

--- a/scripts/skill_cli.py
+++ b/scripts/skill_cli.py
@@ -33,6 +33,11 @@ def add_skill(path: str) -> None:
         meta.get("parameters", {}),
         meta.get("description", ""),
         meta.get("tags", []),
+        meta.get("dependencies_file"),
+        meta.get("entry_point"),
+        meta.get("return_type"),
+        meta.get("author_agent"),
+        meta.get("creation_timestamp"),
     )
     tag = f"skill-{skill.name}-v{skill.version}"
     try:

--- a/tests/unit/test_skill_library.py
+++ b/tests/unit/test_skill_library.py
@@ -1,10 +1,10 @@
 """Tests for :mod:`autogpt.skills.library`."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Dict, List
 
-import json
 import pytest
 
 from autogpt.config import Config
@@ -50,7 +50,19 @@ def test_skill_library_save_and_search(
 
     library = SkillLibrary(config, storage_path=storage, vector_db=vector_db)
 
-    library.add_skill("skill1", "1.0", "code1", {"a": 1}, "description1", ["tag1"])
+    library.add_skill(
+        "skill1",
+        "1.0",
+        "code1",
+        {"a": 1},
+        "description1",
+        ["tag1"],
+        dependencies_file="reqs1.txt",
+        entry_point="main:run",
+        return_type="int",
+        author_agent="agent1",
+        creation_timestamp="2024-01-01T00:00:00Z",
+    )
     library.add_skill("skill2", "1.0", "code2", {"b": 2}, "description2", ["tag2"])
 
     # Ensure skills are persisted and retrievable
@@ -60,10 +72,19 @@ def test_skill_library_save_and_search(
         meta = json.load(f)
     assert meta["skill_name"] == "skill1"
     assert meta["tags"] == ["tag1"]
-    assert library.get_skill("skill1", "1.0")
+    assert meta["dependencies_file"] == "reqs1.txt"
+    assert meta["entry_point"] == "main:run"
+    assert meta["return_type"] == "int"
+    assert meta["author_agent"] == "agent1"
+    assert meta["creation_timestamp"] == "2024-01-01T00:00:00Z"
+    skill1 = library.get_skill("skill1", "1.0")
+    assert skill1
+    assert skill1.metadata.entry_point == "main:run"
 
     # Reload from disk to verify save/load cycle
     new_library = SkillLibrary(config, storage_path=storage, vector_db=MemoryVectorDB())
+    reloaded = new_library.get_skill("skill1", "1.0")
+    assert reloaded and reloaded.metadata.author_agent == "agent1"
 
     results = new_library.search("description1", top_k=1)
     assert results and results[0].name == "skill1"
@@ -109,6 +130,7 @@ def test_skill_library_reindex_and_nested_loading(
                 "description": "description1",
                 "tags": ["tag1"],
                 "parameters": {},
+                "author_agent": "author3",
             }
         )
     )
@@ -127,11 +149,13 @@ def test_skill_library_reindex_and_nested_loading(
                 "description": "description2",
                 "tags": ["tag2"],
                 "parameters": {},
+                "creation_timestamp": "2024-02-02T00:00:00Z",
             }
         )
     )
 
     library.reindex()
-    assert library.get_skill("skill4", "1.0")
+    skill4 = library.get_skill("skill4", "1.0")
+    assert skill4 and skill4.metadata.creation_timestamp == "2024-02-02T00:00:00Z"
     results = library.search("description2", top_k=1)
     assert results and results[0].name == "skill4"

--- a/tests/unit/test_skill_repository.py
+++ b/tests/unit/test_skill_repository.py
@@ -89,19 +89,23 @@ def test_repository_saves_structure_and_parses_metadata(
 
     with (skill_dir / "skill.json").open() as f:
         meta = json.load(f)
-    assert meta == {
-        "skill_name": "skill1",
-        "version": "1.0",
-        "description": "description1",
-        "tags": ["tag1"],
-        "parameters": {"a": 1},
-    }
+    assert meta["skill_name"] == "skill1"
+    assert meta["version"] == "1.0"
+    assert meta["description"] == "description1"
+    assert meta["tags"] == ["tag1"]
+    assert meta["parameters"] == {"a": 1}
+    assert "dependencies_file" in meta
+    assert "entry_point" in meta
+    assert "return_type" in meta
+    assert "author_agent" in meta
+    assert "creation_timestamp" in meta
 
     # Reload repository to ensure metadata is parsed from disk
     new_library = SkillLibrary(config, storage_path=storage, vector_db=DummyVectorDB())
     skill = new_library.get_skill("skill1", "1.0")
     assert skill and skill.description == "description1"
     assert skill.tags == ["tag1"]
+    assert skill.metadata.author_agent is None
 
 
 def test_repository_search_by_description_and_tags(


### PR DESCRIPTION
## Summary
- expand SkillMetadata to track dependencies file, entry point, return type, author agent, and creation timestamp
- plumb new fields through SkillLibrary, public API, and CLI parsing
- test metadata persistence and retrieval for skills

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/skills/library.py autogpt/skills/__init__.py scripts/skill_cli.py tests/unit/test_skill_library.py tests/unit/test_skill_repository.py`
- `pytest tests/unit/test_skill_library.py tests/unit/test_skill_repository.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6891a0432558832faa325332ab077f1e