### PR TITLE
feat: add git clone alias

### DIFF
--- a/autogpt/commands/git_operations.py
+++ b/autogpt/commands/git_operations.py
@@ -16,7 +16,7 @@ from .decorators import sanitize_path_arg
 
 
 @command(
-    "clone_repository",
+    "git_clone",
     "Clones a Repository",
     {
         "url": {
@@ -32,10 +32,11 @@ from .decorators import sanitize_path_arg
     },
     lambda config: bool(config.github_username and config.github_api_key),
     "Configure github_username and github_api_key.",
+    aliases=["clone_repository"],
 )
 @sanitize_path_arg("clone_path")
 @validate_url
-def clone_repository(url: str, clone_path: str, agent: Agent) -> str:
+def git_clone(url: str, clone_path: str, agent: Agent) -> str:
     """Clone a GitHub repository locally.
 
     Args:
@@ -56,6 +57,10 @@ def clone_repository(url: str, clone_path: str, agent: Agent) -> str:
         return f"""Cloned {url} to {clone_path}"""
     except Exception as e:
         return f"Error: {str(e)}"
+
+
+# Backwards compatibility alias
+clone_repository = git_clone
 
 
 @command(

--- a/docs/commands/git_operations.md
+++ b/docs/commands/git_operations.md
@@ -2,7 +2,7 @@
 
 本文介绍常用的 Git 操作以及相关参数，并提供调用示例。
 
-## `git_clone`
+## `git_clone`（别名：`clone_repository`）
 克隆远程仓库到本地。
 
 **参数**

--- a/tests/unit/test_git_commands.py
+++ b/tests/unit/test_git_commands.py
@@ -1,13 +1,14 @@
+from pathlib import Path
+
 import pytest
 from git.exc import GitCommandError
 from git.repo.base import Repo
-from pathlib import Path
 
 from autogpt.agents.agent import Agent
 from autogpt.commands.git_operations import (
-    clone_repository,
     git_blame,
     git_checkout,
+    git_clone,
     git_commit,
     git_create_branch,
     git_push,
@@ -19,7 +20,7 @@ def mock_clone_from(mocker):
     return mocker.patch.object(Repo, "clone_from")
 
 
-def test_clone_auto_gpt_repository(workspace, mock_clone_from, agent: Agent):
+def test_git_clone_auto_gpt_repository(workspace, mock_clone_from, agent: Agent):
     mock_clone_from.return_value = None
 
     repo = "github.com/Significant-Gravitas/Auto-GPT.git"
@@ -29,7 +30,7 @@ def test_clone_auto_gpt_repository(workspace, mock_clone_from, agent: Agent):
 
     expected_output = f"Cloned {url} to {clone_path}"
 
-    clone_result = clone_repository(url=url, clone_path=clone_path, agent=agent)
+    clone_result = git_clone(url=url, clone_path=clone_path, agent=agent)
 
     assert clone_result == expected_output
     mock_clone_from.assert_called_once_with(
@@ -38,7 +39,7 @@ def test_clone_auto_gpt_repository(workspace, mock_clone_from, agent: Agent):
     )
 
 
-def test_clone_repository_error(workspace, mock_clone_from, agent: Agent):
+def test_git_clone_error(workspace, mock_clone_from, agent: Agent):
     url = "https://github.com/this-repository/does-not-exist.git"
     clone_path = str(workspace.get_path("does-not-exist"))
 
@@ -46,7 +47,7 @@ def test_clone_repository_error(workspace, mock_clone_from, agent: Agent):
         "clone", "fatal: repository not found", ""
     )
 
-    result = clone_repository(url=url, clone_path=clone_path, agent=agent)
+    result = git_clone(url=url, clone_path=clone_path, agent=agent)
 
     assert "Error: " in result
 
@@ -107,9 +108,7 @@ def test_git_push_success(mocker, workspace, agent: Agent):
 
     assert result == f"Pushed branch {branch} to remote"
     mock_repo.remote.assert_called_once_with(name="origin")
-    mock_origin.set_url.assert_called_once_with(
-        "https://user:key@github.com/repo.git"
-    )
+    mock_origin.set_url.assert_called_once_with("https://user:key@github.com/repo.git")
     mock_origin.push.assert_called_once_with(branch)
 
 


### PR DESCRIPTION
## Summary
- add `git_clone` command and alias `clone_repository`
- update docs to mention `git_clone` alias
- align git command tests with new `git_clone` name

## Testing
- `pre-commit run --hook-stage manual isort --files autogpt/commands/git_operations.py docs/commands/git_operations.md tests/unit/test_git_commands.py`
- `pre-commit run --hook-stage manual black --files autogpt/commands/git_operations.py docs/commands/git_operations.md tests/unit/test_git_commands.py`
- `pre-commit run --hook-stage manual mypy --files autogpt/commands/git_operations.py tests/unit/test_git_commands.py` *(fails: missing type annotations in tests/unit/test_git_commands.py:96: error: Function is missing a return type annotation  [no-untyped-def]*)
- `pytest tests/unit/test_git_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_6891a40f6010832f875d2f4b594eb8a9