### PR TITLE
feat: structured test results

### DIFF
--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -13,8 +13,6 @@ from autogpt.commands.testing import run_tests
 from autogpt.event_bus import (
     APPROVAL_GRANTED,
     CODE_FIX_PROPOSED,
-    HUMAN_APPROVAL_REQUIRED,
-    ISSUE_RESOLVED,
     ApprovalGranted,
     CodeFixProposed,
     HumanApprovalRequired,
@@ -36,7 +34,9 @@ class QAAgent:
     def _on_code_fix_proposed(self, event: CodeFixProposed) -> None:
         """Handle a ``CODE_FIX_PROPOSED`` event."""
 
-        payload: dict[str, Any] | None = event.payload if isinstance(event.payload, dict) else None
+        payload: dict[str, Any] | None = (
+            event.payload if isinstance(event.payload, dict) else None
+        )
         repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
 
         branch = event.branch_name
@@ -45,12 +45,12 @@ class QAAgent:
 
         git_checkout(repo_path, branch, self.agent)
 
-        test_output = run_tests(repo_path, self.agent)
+        test_result = run_tests(repo_path, self.agent)
 
         self.message_queue.publish(
             HumanApprovalRequired(
                 branch_name=branch,
-                test_output=test_output,
+                test_output=test_result["logs"],
                 summary=event.summary,
                 source_agent="qa_agent",
             )
@@ -59,7 +59,9 @@ class QAAgent:
     def _on_approval_granted(self, event: ApprovalGranted) -> None:
         """Handle an ``APPROVAL_GRANTED`` event."""
 
-        payload: dict[str, Any] | None = event.payload if isinstance(event.payload, dict) else None
+        payload: dict[str, Any] | None = (
+            event.payload if isinstance(event.payload, dict) else None
+        )
         repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
 
         branch = event.branch_name

--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -8,14 +8,9 @@ from typing import Any
 from git import Repo
 
 from autogpt.agents.agent import Agent
-from autogpt.commands.git_operations import (
-    git_checkout,
-    git_commit,
-    git_create_branch,
-)
+from autogpt.commands.git_operations import git_checkout, git_commit, git_create_branch
 from autogpt.commands.testing import create_test_file, run_tests
 from autogpt.event_bus import (
-    CODE_FIX_PROPOSED,
     DIAGNOSIS_COMPLETE,
     CodeFixProposed,
     EventMessage,
@@ -58,11 +53,14 @@ class TDDDeveloper:
         create_test_file(str(test_file), test_content, self.agent)
 
         initial_result = run_tests(str(test_file), self.agent)
-        if "failed" not in initial_result.lower():
+        if (
+            initial_result.get("failures", 0) == 0
+            and initial_result.get("errors", 0) == 0
+        ):
             return
 
         final_result = run_tests(repo_path, self.agent)
-        if "failed" in final_result.lower():
+        if final_result.get("failures", 0) > 0 or final_result.get("errors", 0) > 0:
             return
 
         git_commit(repo_path, f"Fix issue {issue_id}", self.agent)

--- a/autogpt/commands/testing.py
+++ b/autogpt/commands/testing.py
@@ -3,8 +3,13 @@
 COMMAND_CATEGORY = "testing"
 COMMAND_CATEGORY_TITLE = "Testing"
 
-import subprocess
+import io
+import os
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import Any, Dict
+
+import pytest
 
 from autogpt.agents.agent import Agent
 from autogpt.command_decorator import command
@@ -25,26 +30,58 @@ from .file_operations import write_to_file
     },
 )
 @sanitize_path_arg("path")
-def run_tests(path: str, agent: Agent) -> str:
-    """Run tests using pytest and return the combined output.
+def run_tests(path: str, agent: Agent) -> Dict[str, Any]:
+    """Run tests using pytest and return structured results.
 
     Args:
         path: Path to the tests to run.
         agent: The Agent running the command.
 
     Returns:
-        stdout and stderr from running pytest, or an error message.
+        Dict with keys ``successes``, ``failures``, ``errors`` and ``logs``.
     """
+
+    class ResultAggregator:
+        """Pytest plugin to aggregate test results."""
+
+        def __init__(self) -> None:
+            self.passed = 0
+            self.failed = 0
+            self.errors = 0
+
+        def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:  # type: ignore[override]
+            if report.when == "call":
+                if report.passed:
+                    self.passed += 1
+                elif report.failed:
+                    self.failed += 1
+            elif report.failed:
+                self.errors += 1
+
+    aggregator = ResultAggregator()
+    output_buffer = io.StringIO()
+
     try:
-        result = subprocess.run(
-            ["pytest", path],
-            capture_output=True,
-            text=True,
-            cwd=agent.config.workspace_path,
-        )
-        return result.stdout + result.stderr
-    except Exception as e:
-        return f"Error: {e}"
+        prev_cwd = os.getcwd()
+        os.chdir(agent.config.workspace_path)
+        with redirect_stdout(output_buffer), redirect_stderr(output_buffer):
+            pytest.main([path], plugins=[aggregator])
+    except Exception as e:  # pragma: no cover - defensive programming
+        return {
+            "successes": 0,
+            "failures": 0,
+            "errors": 1,
+            "logs": f"Error: {e}",
+        }
+    finally:
+        os.chdir(prev_cwd)
+
+    return {
+        "successes": aggregator.passed,
+        "failures": aggregator.failed,
+        "errors": aggregator.errors,
+        "logs": output_buffer.getvalue(),
+    }
 
 
 @command(

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -1,10 +1,8 @@
 import importlib
 import sys
 import types
-
 from pathlib import Path
 
-import pytest
 from pytest_mock import MockerFixture
 
 from autogpt.event_bus import (
@@ -51,14 +49,25 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     QAAgent(agent=agent, message_queue=message_queue)
 
     assert message_queue.subscribe.call_count == 2
-    callbacks = {call.args[0]: call.args[1] for call in message_queue.subscribe.call_args_list}
+    callbacks = {
+        call.args[0]: call.args[1] for call in message_queue.subscribe.call_args_list
+    }
     assert set(callbacks.keys()) == {CODE_FIX_PROPOSED, APPROVAL_GRANTED}
 
     on_code_fix_proposed = callbacks[CODE_FIX_PROPOSED]
     on_approval_granted = callbacks[APPROVAL_GRANTED]
 
     git_checkout = mocker.patch.object(qa_module, "git_checkout")
-    run_tests = mocker.patch.object(qa_module, "run_tests", return_value="tests passed")
+    run_tests = mocker.patch.object(
+        qa_module,
+        "run_tests",
+        return_value={
+            "successes": 1,
+            "failures": 0,
+            "errors": 0,
+            "logs": "tests passed",
+        },
+    )
     repo_mock = mocker.MagicMock()
     repo_mock.git.checkout.return_value = ""
     repo_mock.git.merge.return_value = ""
@@ -79,12 +88,16 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
 
     message_queue.publish.reset_mock()
 
-    approval_event = ApprovalGranted(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
+    approval_event = ApprovalGranted(
+        branch_name="fix/123", commit_hash="abc", summary="Fix bug"
+    )
     on_approval_granted(approval_event)
 
     repo_mock.git.checkout.assert_called_once_with("main")
     repo_mock.git.merge.assert_called_once_with("fix/123")
-    subprocess_run.assert_called_once_with(["bash", "scripts/deploy.sh"], cwd=str(tmp_path), check=False)
+    subprocess_run.assert_called_once_with(
+        ["bash", "scripts/deploy.sh"], cwd=str(tmp_path), check=False
+    )
     message_queue.publish.assert_called_once()
     resolved_event = message_queue.publish.call_args[0][0]
     assert isinstance(resolved_event, IssueResolved)

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import types
-from pathlib import Path
 
 from autogpt.event_bus import (
     CODE_FIX_PROPOSED,
@@ -19,6 +18,7 @@ sys.modules.setdefault("autogpt.agents", agents_pkg)
 tdd_module = importlib.import_module("autogpt.agents.tdd_developer")
 TDDDeveloper = tdd_module.TDDDeveloper
 
+
 def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
@@ -34,22 +34,24 @@ def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
         "autogpt.agents.tdd_developer.create_test_file", return_value=""
     )
     run = mocker.patch(
-        "autogpt.agents.tdd_developer.run_tests", side_effect=["1 failed", "1 passed"]
+        "autogpt.agents.tdd_developer.run_tests",
+        side_effect=[
+            {"successes": 0, "failures": 1, "errors": 0, "logs": "1 failed"},
+            {"successes": 1, "failures": 0, "errors": 0, "logs": "1 passed"},
+        ],
     )
-    commit = mocker.patch(
-        "autogpt.agents.tdd_developer.git_commit", return_value=""
-    )
+    commit = mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
 
     received: list[EventMessage] = []
-    message_queue.subscribe(
-        CODE_FIX_PROPOSED, lambda msg: received.append(msg)
-    )
+    message_queue.subscribe(CODE_FIX_PROPOSED, lambda msg: received.append(msg))
 
     repo_path = str(workspace.root)
     payload = {"issue_id": "123", "repo_path": repo_path, "diagnostics": "details"}
 
     message_queue.publish(
-        EventMessage(event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester")
+        EventMessage(
+            event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+        )
     )
 
     create_branch.assert_called_once_with(repo_path, "fix/123", agent)

--- a/tests/unit/test_tdd_developer_agent.py
+++ b/tests/unit/test_tdd_developer_agent.py
@@ -11,25 +11,36 @@ agents_pkg.__path__ = ["autogpt/agents"]
 sys.modules.setdefault("autogpt.agents", agents_pkg)
 
 agent_stub = types.ModuleType("autogpt.agents.agent")
+
+
 class Agent:  # minimal stub to satisfy imports
     pass
+
+
 agent_stub.Agent = Agent
 sys.modules.setdefault("autogpt.agents.agent", agent_stub)
 
 # Stub memory and text processing modules to avoid heavy dependencies
 memory_pkg = types.ModuleType("autogpt.memory")
 vector_stub = types.ModuleType("autogpt.memory.vector")
+
+
 class MemoryItem:  # minimal stub
     pass
+
+
 class VectorMemory:  # minimal stub
     pass
+
+
 vector_stub.MemoryItem = MemoryItem
 vector_stub.VectorMemory = VectorMemory
 memory_pkg.vector = vector_stub
 sys.modules.setdefault("autogpt.memory", memory_pkg)
 sys.modules.setdefault("autogpt.memory.vector", vector_stub)
 sys.modules.setdefault(
-    "autogpt.memory.vector.providers", types.ModuleType("autogpt.memory.vector.providers")
+    "autogpt.memory.vector.providers",
+    types.ModuleType("autogpt.memory.vector.providers"),
 )
 
 processing_stub = types.ModuleType("autogpt.processing.text")
@@ -63,11 +74,18 @@ def test_tdd_developer_agent_flow(tmp_path, mocker):
     subscribed_event, callback = message_queue.subscribe.call_args[0]
     assert subscribed_event == DIAGNOSIS_COMPLETE
 
-    create_branch = mocker.patch.object(tdd_module, "git_create_branch", return_value="")
+    create_branch = mocker.patch.object(
+        tdd_module, "git_create_branch", return_value=""
+    )
     checkout = mocker.patch.object(tdd_module, "git_checkout", return_value="")
     create_test = mocker.patch.object(tdd_module, "create_test_file", return_value="")
     run = mocker.patch.object(
-        tdd_module, "run_tests", side_effect=["1 failed", "1 passed"]
+        tdd_module,
+        "run_tests",
+        side_effect=[
+            {"successes": 0, "failures": 1, "errors": 0, "logs": "1 failed"},
+            {"successes": 1, "failures": 0, "errors": 0, "logs": "1 passed"},
+        ],
     )
     commit = mocker.patch.object(tdd_module, "git_commit", return_value="")
     mocker.patch.object(tdd_module, "Repo", side_effect=Exception("git error"))
@@ -91,10 +109,12 @@ def test_tdd_developer_agent_flow(tmp_path, mocker):
     )
 
     assert run.call_count == 2
-    run.assert_has_calls([
-        mocker.call(str(expected_test_file), agent),
-        mocker.call(repo_path, agent),
-    ])
+    run.assert_has_calls(
+        [
+            mocker.call(str(expected_test_file), agent),
+            mocker.call(repo_path, agent),
+        ]
+    )
 
     commit.assert_called_once_with(repo_path, "Fix issue 123", agent)
 

--- a/tests/unit/test_testing_command.py
+++ b/tests/unit/test_testing_command.py
@@ -10,7 +10,10 @@ def test_run_tests_success(workspace, agent: Agent):
         f.write("def test_example():\n    assert True\n")
 
     result = run_tests(str(test_file), agent=agent)
-    assert "1 passed" in result
+    assert result["successes"] == 1
+    assert result["failures"] == 0
+    assert result["errors"] == 0
+    assert "1 passed" in result["logs"]
 
 
 def test_run_tests_invalid_path(agent: Agent):


### PR DESCRIPTION
## Summary
- return structured results from `run_tests` using pytest API
- update TDD developer and QA agent to consume structured test data
- extend unit tests for new run_tests output

## Testing
- `pre-commit run --files autogpt/commands/testing.py autogpt/agents/tdd_developer.py autogpt/agents/qa_agent.py tests/unit/test_testing_command.py tests/unit/test_tdd_developer_agent.py tests/unit/test_tdd_developer.py tests/unit/test_qa_agent.py` *(failed: ModuleNotFoundError: No module named 'requests')*
- `pytest tests/unit/test_testing_command.py tests/unit/test_tdd_developer_agent.py tests/unit/test_tdd_developer.py tests/unit/test_qa_agent.py` *(failed: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6891a6b5e01c832f8762bdd71df62773