### PR TITLE
Add Faiss vector database provider for skills

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -106,6 +106,7 @@ Select the backend with `SKILL_DB_PROVIDER` in `.env`:
 
 - `memory` (default) — in-memory only;
 - `chroma` — install with `pip install chromadb` to persist data in `skill_library/chroma`.
+- `faiss` — install with `pip install faiss-cpu` to persist data in `skill_library/faiss`.
 
 ## Running the app
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cp .env.template .env
 
 - `memory`（默认） — 使用内存实现，运行结束后数据会丢失；
 - `chroma` — 需要先 `pip install chromadb`，数据会持久化到 `skill_library/chroma`。
+- `faiss` — 需要先 `pip install faiss-cpu`，数据会持久化到 `skill_library/faiss`。
 
 ## 消息队列
 

--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -12,7 +12,13 @@ from typing import Dict, List, Optional
 from autogpt.config import Config
 from autogpt.memory.vector.utils import get_embedding
 
-from .vector_db import ChromaVectorDB, Embedding, MemoryVectorDB, VectorDBProvider
+from .vector_db import (
+    ChromaVectorDB,
+    Embedding,
+    FaissVectorDB,
+    MemoryVectorDB,
+    VectorDBProvider,
+)
 
 
 @dataclass
@@ -78,6 +84,9 @@ class SkillLibrary:
             if provider == "chroma":
                 persist = self.storage_path / "chroma"
                 self.vector_db = ChromaVectorDB(persist)
+            elif provider == "faiss":
+                persist = self.storage_path / "faiss"
+                self.vector_db = FaissVectorDB(persist)
             else:
                 self.vector_db = MemoryVectorDB()
         self._skills: Dict[str, Skill] = {}

--- a/autogpt/skills/vector_db.py
+++ b/autogpt/skills/vector_db.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import chromadb
+import faiss
+import json
 import numpy as np
 
 Embedding = List[float]
@@ -119,3 +121,74 @@ class ChromaVectorDB(VectorDBProvider):
         ids = self._collection.get()["ids"]
         if ids:
             self._collection.delete(ids=ids)
+
+
+class FaissVectorDB(VectorDBProvider):
+    """`VectorDBProvider` backed by a FAISS index with JSON metadata storage."""
+
+    def __init__(self, persist_path: Path) -> None:
+        self.persist_path = Path(persist_path)
+        self.persist_path.mkdir(parents=True, exist_ok=True)
+        self.data_file = self.persist_path / "data.json"
+        if self.data_file.exists():
+            with self.data_file.open("r", encoding="utf-8") as f:
+                self._data: Dict[str, Dict] = json.load(f)
+        else:
+            self._data = {}
+        self._rebuild_index()
+
+    # internal helpers -------------------------------------------------
+    def _save(self) -> None:
+        with self.data_file.open("w", encoding="utf-8") as f:
+            json.dump(self._data, f)
+
+    def _rebuild_index(self) -> None:
+        if self._data:
+            dim = len(next(iter(self._data.values()))["embedding"])
+            self._index = faiss.IndexFlatIP(dim)
+            embeddings = [v["embedding"] for v in self._data.values()]
+            emb_array = np.array(embeddings, dtype="float32")
+            faiss.normalize_L2(emb_array)
+            self._index.add(emb_array)
+            self._keys = list(self._data.keys())
+        else:
+            self._index = None
+            self._keys = []
+
+    # VectorDBProvider API ---------------------------------------------
+    def add(self, key: str, embedding: Embedding, metadata: Dict | None = None) -> None:
+        self._data[key] = {
+            "embedding": list(map(float, embedding)),
+            "metadata": metadata or {},
+        }
+        self._save()
+        self._rebuild_index()
+
+    def delete(self, key: str) -> None:
+        if key in self._data:
+            del self._data[key]
+            self._save()
+            self._rebuild_index()
+
+    def query(self, embedding: Embedding, top_k: int = 5) -> List[Tuple[str, float]]:
+        if not self._index or not self._keys or top_k <= 0:
+            return []
+        vec = np.array([embedding], dtype="float32")
+        faiss.normalize_L2(vec)
+        scores, idxs = self._index.search(vec, top_k)
+        results: List[Tuple[str, float]] = []
+        for score, idx in zip(scores[0], idxs[0]):
+            if 0 <= idx < len(self._keys):
+                results.append((self._keys[idx], float(score)))
+        return results
+
+    def get(self, key: str) -> Tuple[Embedding, Dict] | None:
+        item = self._data.get(key)
+        if item is None:
+            return None
+        return item["embedding"], item["metadata"]
+
+    def clear(self) -> None:
+        self._data.clear()
+        self._save()
+        self._rebuild_index()

--- a/tests/unit/test_faiss_vector_db.py
+++ b/tests/unit/test_faiss_vector_db.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from autogpt.skills.vector_db import FaissVectorDB
+
+
+def test_faiss_add_query_delete(tmp_path: Path) -> None:
+    db = FaissVectorDB(tmp_path)
+    db.add("skill1", [1.0, 0.0], {"a": 1})
+    db.add("skill2", [0.0, 1.0], {"b": 2})
+
+    res = db.query([1.0, 0.0], top_k=2)
+    assert res[0][0] == "skill1"
+
+    # persistence across instances
+    db2 = FaissVectorDB(tmp_path)
+    emb, meta = db2.get("skill1")
+    assert meta["a"] == 1
+
+    db2.delete("skill1")
+    assert db2.get("skill1") is None


### PR DESCRIPTION
## Summary
- add persistent FaissVectorDB implementing VectorDBProvider
- allow SkillLibrary to choose Chroma or Faiss via SKILL_DB_PROVIDER
- document vector DB configuration options
- test Faiss add/query/delete

## Testing
- `pytest tests/unit/test_faiss_vector_db.py tests/unit/test_chroma_vector_db.py tests/unit/test_skill_library.py`

------
https://chatgpt.com/codex/tasks/task_e_6891a89cb2d8832f8b8e708c565abbb8