### PR TITLE
feat: add pubsub optional dependency and logging

### DIFF
--- a/autogpt/event_bus/message_queue.py
+++ b/autogpt/event_bus/message_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Lightweight publish/subscribe message queue with optional backend."""
 
+import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable
 
@@ -24,9 +25,16 @@ class MessageQueue:
 
     def __init__(self, event_bus: "EventBus" | None = None) -> None:
         self.event_bus = event_bus
-        self._handlers: DefaultDict[
-            str, list[Callable[[EventMessage], None]]
-        ] = defaultdict(list)
+        self._handlers: DefaultDict[str, list[Callable[[EventMessage], None]]] = (
+            defaultdict(list)
+        )
+
+        if not _HAS_PUBSUB:
+            logging.getLogger(__name__).warning(
+                "PyPubSub not installed; using in-process fallback. "
+                "Install 'pypubsub' or configure an external message queue for "
+                "inter-agent communication."
+            )
 
     # -- Core API -----------------------------------------------------
     def publish(self, event: EventMessage) -> None:

--- a/docs/configuration/message_queue.md
+++ b/docs/configuration/message_queue.md
@@ -21,14 +21,19 @@ Agent -> MessageQueue -> (PyPubSub backend | in-process fallback) -> Subscribers
 ## Configuration
 
 No configuration is required to use the built‑in queue. Installing PyPubSub
-is recommended for cross-module communication. The event database is created
-at `<workspace>/events.db` by default.
+enables cross-module communication through a shared bus. The event database is
+created at `<workspace>/events.db` by default.
 
 ### Installing the default backend (PyPubSub)
 
+Install the optional dependency to enable the PyPubSub backend:
+
 ```bash
-pip install pypubsub
+pip install agpt[pubsub]  # or: pip install pypubsub
 ```
+
+Once installed, Auto‑GPT will automatically use PyPubSub when creating a
+`MessageQueue`.
 
 ### Alternative brokers
 
@@ -58,6 +63,17 @@ class EventMessage:
     payload: dict[str, Any] | str | None = None
     source_agent: str | None = None
     timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+```
+
+A standard message therefore contains:
+
+```json
+{
+  "event_type": "status",
+  "payload": {"msg": "hi"},
+  "source_agent": "agent",
+  "timestamp": "2023-01-01T00:00:00Z"
+}
 ```
 
 ## Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ test = [
     "pytest-xdist",
 ]
 
+pubsub = [
+    "pypubsub",
+]
+
 alphaevolve = [
     "flask",
 ]


### PR DESCRIPTION
## Summary
- add optional `pubsub` extra with `pypubsub`
- document how to install/enable PyPubSub and message format
- warn when falling back without PyPubSub

## Testing
- `pre-commit run --files pyproject.toml docs/configuration/message_queue.md autogpt/event_bus/message_queue.py` (fails: autoflake modified other files; pytest-check missing jsonschema)
- `pytest tests/unit/test_event_bus.py::test_event_bus_emit_and_read -q` (fails: ModuleNotFoundError: No module named 'colorama')

------
https://chatgpt.com/codex/tasks/task_e_6891aab6f5bc832f91a7a0197a4e9f99