### PR TITLE
Enhance archaeologist diagnostics with detailed reports

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from autogpt.event_bus import (
+    ISSUE_DETECTED,
     DiagnosisComplete,
     EventMessage,
     MessageQueue,
-    ISSUE_DETECTED,
 )
 
 from .archaeologist_dependency import analyze_dependency
@@ -46,7 +46,7 @@ class Archaeologist:
             if "line" not in metadata and line is not None:
                 metadata["line"] = line
 
-        analysis = {
+        analysis: dict[str, Any] = {
             "checkout": self._checkout_commit(metadata.get("commit")),
             "blame": self._git_blame(metadata.get("file"), metadata.get("line")),
             "dependencies": self._review_dependencies(metadata.get("file")),
@@ -64,10 +64,24 @@ class Archaeologist:
             summary_parts.append(f"at {location}")
         summary = " ".join(summary_parts)
 
+        blame_info = self._parse_blame_output(analysis.get("blame"))
+        context = []
+        if metadata.get("file") and metadata.get("line") is not None:
+            context = self._source_context(metadata["file"], metadata["line"])
+
+        details = {
+            "metadata": metadata,
+            "error_log": error_log,
+            "blame": blame_info,
+            "context": context,
+            "dependencies": analysis.get("dependencies"),
+        }
+
         self.message_queue.publish(
             DiagnosisComplete(
                 summary=summary,
                 actionable_recommendations=recommendations,
+                details=details,
                 source_agent="archaeologist",
             )
         )
@@ -123,6 +137,37 @@ class Archaeologist:
         cmd.append(file)
         result = subprocess.run(cmd, capture_output=True, text=True)
         return result.stdout.strip()
+
+    def _parse_blame_output(self, blame: str | None) -> dict[str, Any] | None:
+        """Parse commit hash and author from ``git blame`` output."""
+
+        if not blame:
+            return None
+        first_line = blame.splitlines()[0]
+        match = re.match(
+            r"^(?P<commit>\S+)\s+\((?P<author>.+?)\s+\d{4}-\d{2}-\d{2}",
+            first_line,
+        )
+        if match:
+            return {
+                "commit": match.group("commit"),
+                "author": match.group("author").strip(),
+                "text": blame,
+            }
+        return {"text": blame}
+
+    def _source_context(
+        self, file: str, line: int, span: int = 2
+    ) -> list[dict[str, Any]]:
+        """Return source lines surrounding ``line`` from ``file``."""
+
+        try:
+            lines = Path(file).read_text().splitlines()
+        except Exception:
+            return []
+        start = max(line - span - 1, 0)
+        end = min(line + span, len(lines))
+        return [{"line": i + 1, "content": lines[i]} for i in range(start, end)]
 
     def _review_dependencies(self, file: str | None) -> list[dict[str, Any]]:
         """Analyze imported modules from ``file`` for compatibility issues."""

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -79,6 +79,7 @@ class EventBus:
                     actionable_recommendations=str(
                         payload_obj.get("actionable_recommendations", "")
                     ),
+                    details=payload_obj.get("details"),
                     source_agent=source_agent,
                     timestamp=ts,
                 )

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -44,6 +44,7 @@ class DiagnosisComplete(EventMessage):
 
     summary: str
     actionable_recommendations: str
+    details: dict[str, Any] | None = None
     event_type: str = field(init=False, default=DIAGNOSIS_COMPLETE)
     payload: dict[str, Any] | str | None = field(init=False)
 
@@ -51,6 +52,7 @@ class DiagnosisComplete(EventMessage):
         self.payload = {
             "summary": self.summary,
             "actionable_recommendations": self.actionable_recommendations,
+            "details": self.details,
         }
 
 

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 from autogpt.event_bus import (
     DIAGNOSIS_COMPLETE,
+    ISSUE_DETECTED,
     DiagnosisComplete,
     EventBus,
     EventMessage,
     MessageQueue,
-    ISSUE_DETECTED,
 )
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
@@ -46,6 +46,11 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     diag = received[0]
     assert "test_plugin" in diag.summary
     assert isinstance(diag.actionable_recommendations, str)
+    assert diag.details is not None
+    assert diag.details["blame"]["commit"]
+    assert diag.details["blame"]["author"]
+    assert any(c["line"] == 10 for c in diag.details["context"])
+    assert isinstance(diag.details["dependencies"], list)
 
 
 def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 
 from autogpt.event_bus import (
     DIAGNOSIS_COMPLETE,
+    ISSUE_DETECTED,
     DiagnosisComplete,
     EventMessage,
     MessageQueue,
-    ISSUE_DETECTED,
 )
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
@@ -35,7 +35,9 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
 
     commands: list[list[str]] = []
 
-    def fake_run(cmd, capture_output=True, text=True):
+    def fake_run(
+        cmd: list[str], capture_output: bool = True, text: bool = True
+    ) -> SimpleNamespace:
         commands.append(cmd)
         if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
             return SimpleNamespace(stdout="main\n", stderr="")
@@ -68,7 +70,9 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
             "commit": "abc123",
         }
         message_queue.publish(
-            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
         )
 
     assert any(cmd[:2] == ["git", "checkout"] for cmd in commands)
@@ -80,4 +84,14 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
     diag = received[0]
     expected_summary = f"Diagnostics for plugin test_plugin at {source_file}:1"
     assert diag.summary == expected_summary
-    assert "Investigate compatibility issues in: sample_dep" in diag.actionable_recommendations
+    assert (
+        "Investigate compatibility issues in: sample_dep"
+        in diag.actionable_recommendations
+    )
+    assert diag.details is not None
+    blame = diag.details["blame"]
+    assert blame["commit"] == "^123"
+    assert blame["author"] == "user"
+    assert blame["text"].startswith("^123")
+    assert diag.details["context"][0]["content"].strip() == "import sample_dep"
+    assert diag.details["dependencies"][0]["dependency"] == "sample_dep"


### PR DESCRIPTION
## Summary
- include blame metadata, file context, dependencies, error log and metadata in archaeologist diagnostic details
- add `details` field to `DiagnosisComplete` event and serialize it through the event bus
- extend archaeologist unit tests to assert detailed diagnostics

## Testing
- `pytest tests/unit/test_archaeologist.py::test_archaeologist_handles_issue tests/unit/test_archaeologist_agent.py::test_archaeologist_agent_diagnosis_complete -q`
- `pre-commit run --files autogpt/agents/archaeologist.py autogpt/event_bus/message_types.py autogpt/event_bus/__init__.py tests/unit/test_archaeologist.py tests/unit/test_archaeologist_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6891bf745d18832fb84f1873120fd1bc