### PR TITLE
feat: implement iterative code fixing for TDD developer

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -1,13 +1,14 @@
-from __future__ import annotations
-
 """Event-driven TDD developer agent that responds to diagnostics."""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
-from git import Repo
+from git import Repo  # type: ignore[import-not-found]
 
 from autogpt.agents.agent import Agent
+from autogpt.commands.file_operations import write_to_file
 from autogpt.commands.git_operations import git_checkout, git_commit, git_create_branch
 from autogpt.commands.testing import create_test_file, run_tests
 from autogpt.event_bus import (
@@ -59,21 +60,35 @@ class TDDDeveloper:
         ):
             return
 
-        final_result = run_tests(repo_path, self.agent)
-        if final_result.get("failures", 0) > 0 or final_result.get("errors", 0) > 0:
-            return
+        fixes: list[dict[str, str]] = []
+        if isinstance(diagnostics, dict):
+            fixes = diagnostics.get("fixes", []) or []
 
-        git_commit(repo_path, f"Fix issue {issue_id}", self.agent)
-        try:
-            commit_hash = Repo(repo_path).head.commit.hexsha
-        except Exception:
-            commit_hash = ""
+        max_iterations = payload.get("max_iterations", len(fixes) or 1)
 
-        self.message_queue.publish(
-            CodeFixProposed(
-                branch_name=branch,
-                commit_hash=commit_hash,
-                summary=f"Fix issue {issue_id}",
-                source_agent="tdd_developer",
-            )
-        )
+        for i in range(max_iterations):
+            if i < len(fixes):
+                for rel_path, new_content in fixes[i].items():
+                    file_path = Path(repo_path) / rel_path
+                    write_to_file(str(file_path), new_content, self.agent)
+
+            result = run_tests(repo_path, self.agent)
+            if result.get("failures", 0) == 0 and result.get("errors", 0) == 0:
+                git_commit(repo_path, f"Fix issue {issue_id}", self.agent)
+                try:
+                    commit_hash = Repo(repo_path).head.commit.hexsha
+                except Exception:
+                    commit_hash = ""
+
+                self.message_queue.publish(
+                    CodeFixProposed(
+                        branch_name=branch,
+                        commit_hash=commit_hash,
+                        summary=f"Fix issue {issue_id}",
+                        source_agent="tdd_developer",
+                    )
+                )
+                return
+
+        # If we exit the loop without passing tests, no commit or event is produced
+        return

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -1,7 +1,11 @@
 import importlib
 import sys
 import types
+from pathlib import Path
 
+from pytest_mock import MockerFixture
+
+from autogpt.agents.agent import Agent
 from autogpt.event_bus import (
     CODE_FIX_PROPOSED,
     DIAGNOSIS_COMPLETE,
@@ -9,6 +13,7 @@ from autogpt.event_bus import (
     EventMessage,
     MessageQueue,
 )
+from autogpt.workspace import Workspace
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
 agents_pkg = types.ModuleType("autogpt.agents")
@@ -19,7 +24,9 @@ tdd_module = importlib.import_module("autogpt.agents.tdd_developer")
 TDDDeveloper = tdd_module.TDDDeveloper
 
 
-def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
+def test_tdd_developer_handles_diagnosis(
+    agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
+) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
     TDDDeveloper(agent=agent, message_queue=message_queue)
@@ -33,11 +40,15 @@ def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     create_test = mocker.patch(
         "autogpt.agents.tdd_developer.create_test_file", return_value=""
     )
+    write_file = mocker.patch(
+        "autogpt.agents.tdd_developer.write_to_file", return_value=""
+    )
     run = mocker.patch(
         "autogpt.agents.tdd_developer.run_tests",
         side_effect=[
             {"successes": 0, "failures": 1, "errors": 0, "logs": "1 failed"},
-            {"successes": 1, "failures": 0, "errors": 0, "logs": "1 passed"},
+            {"successes": 1, "failures": 1, "errors": 0, "logs": "1 failed"},
+            {"successes": 2, "failures": 0, "errors": 0, "logs": "2 passed"},
         ],
     )
     commit = mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
@@ -46,7 +57,16 @@ def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     message_queue.subscribe(CODE_FIX_PROPOSED, lambda msg: received.append(msg))
 
     repo_path = str(workspace.root)
-    payload = {"issue_id": "123", "repo_path": repo_path, "diagnostics": "details"}
+    payload = {
+        "issue_id": "123",
+        "repo_path": repo_path,
+        "diagnostics": {
+            "fixes": [
+                {"module.py": "print('fix1')"},
+                {"module.py": "print('fix2')"},
+            ]
+        },
+    }
 
     message_queue.publish(
         EventMessage(
@@ -57,7 +77,8 @@ def test_tdd_developer_handles_diagnosis(agent, workspace, tmp_path, mocker):
     create_branch.assert_called_once_with(repo_path, "fix/123", agent)
     checkout.assert_called_once_with(repo_path, "fix/123", agent)
     create_test.assert_called_once()
-    assert run.call_count == 2
+    assert write_file.call_count == 2
+    assert run.call_count == 3
     commit.assert_called_once_with(repo_path, "Fix issue 123", agent)
     assert len(received) == 1
     assert received[0].event_type == CODE_FIX_PROPOSED


### PR DESCRIPTION
## Summary
- add iterative fix loop to TDD developer that writes patches and re-runs tests
- publish CodeFixProposed after successful fixes
- test iterative fixing and event emission

## Testing
- `ruff check autogpt/agents/tdd_developer.py tests/unit/test_tdd_developer.py`
- `mypy autogpt/agents/tdd_developer.py tests/unit/test_tdd_developer.py`
- `black --check autogpt/agents/tdd_developer.py tests/unit/test_tdd_developer.py`
- `isort --check-only autogpt/agents/tdd_developer.py tests/unit/test_tdd_developer.py`
- `pytest tests/unit/test_tdd_developer.py`


------
https://chatgpt.com/codex/tasks/task_e_6891bf88fb70832f9b12ec19fdc15fa0