### PR TITLE
feat: generate tests from diagnostics

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import re
 
 from git import Repo  # type: ignore[import-not-found]
 
@@ -47,9 +48,31 @@ class TDDDeveloper:
         git_checkout(repo_path, branch, self.agent)
 
         test_file = Path(repo_path) / "tests" / f"test_issue_{issue_id}.py"
+
+        # Attempt to parse stack traces like: File "<path>", line X, in <func>
+        diag_text = diagnostics if isinstance(diagnostics, str) else ""
+        file_match = re.search(r'File "([^"]+)", line \d+, in (\w+)', diag_text)
+        err_match = re.search(r'^(\w+(?:Error|Exception))', diag_text.splitlines()[-1]) if diag_text else None
+
+        test_body = diag_text
+        if file_match and err_match:
+            file_path, func_name = file_match.groups()
+            error_type = err_match.group(1)
+            try:
+                rel_path = Path(file_path).relative_to(repo_path)
+                module = rel_path.with_suffix("").as_posix().replace("/", ".")
+                test_body = (
+                    f"import pytest\nfrom {module} import {func_name}\n\n"
+                    f"def test_issue_{issue_id}():\n"
+                    f"    with pytest.raises({error_type}):\n"
+                    f"        {func_name}()\n"
+                )
+            except ValueError:
+                # If path is outside repo, fall back to including diagnostics text
+                test_body = diag_text
+
         test_content = (
-            f"# Auto-generated regression test for issue {issue_id}\n"
-            f"{diagnostics or ''}\n"
+            f"# Auto-generated regression test for issue {issue_id}\n" f"{test_body}\n"
         )
         create_test_file(str(test_file), test_content, self.agent)
 

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -85,3 +85,54 @@ def test_tdd_developer_handles_diagnosis(
     assert received[0].payload["branch_name"] == "fix/123"
     assert received[0].payload["summary"] == "Fix issue 123"
     assert "commit_hash" in received[0].payload
+
+
+def test_tdd_developer_generates_repro_test(
+    agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    TDDDeveloper(agent=agent, message_queue=message_queue)
+
+    mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")
+    mocker.patch("autogpt.agents.tdd_developer.git_checkout", return_value="")
+    mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
+
+    captured: dict[str, str] = {}
+
+    def capture_create_test_file(path: str, content: str, *_: object) -> str:
+        captured["content"] = content
+        return ""
+
+    mocker.patch(
+        "autogpt.agents.tdd_developer.create_test_file", side_effect=capture_create_test_file
+    )
+
+    mocker.patch(
+        "autogpt.agents.tdd_developer.run_tests",
+        side_effect=[
+            {"successes": 0, "failures": 1, "errors": 0},
+            {"successes": 0, "failures": 1, "errors": 0},
+        ],
+    )
+
+    repo_path = str(workspace.root)
+    module_path = Path(repo_path) / "buggy.py"
+    diag = (
+        "Traceback (most recent call last):\n"
+        f"  File \"{module_path}\", line 1, in buggy_fn\n"
+        "    buggy_fn()\n"
+        "ValueError: boom\n"
+    )
+
+    payload = {"issue_id": "456", "repo_path": repo_path, "diagnostics": diag}
+
+    message_queue.publish(
+        EventMessage(
+            event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+        )
+    )
+
+    content = captured.get("content", "")
+    assert "from buggy import buggy_fn" in content
+    assert "pytest.raises(ValueError)" in content


### PR DESCRIPTION
## Summary
- parse diagnostic stack traces to craft minimal regression tests with pytest.raises
- verify test generation from stack trace in TDDDeveloper

## Testing
- `pytest tests/unit/test_tdd_developer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c2f38ae0832f92136c123e9e6eda