### PR TITLE
feat: analyze dependencies using new version metadata

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -49,7 +49,9 @@ class Archaeologist:
         analysis: dict[str, Any] = {
             "checkout": self._checkout_commit(metadata.get("commit")),
             "blame": self._git_blame(metadata.get("file"), metadata.get("line")),
-            "dependencies": self._review_dependencies(metadata.get("file")),
+            "dependencies": self._review_dependencies(
+                metadata.get("file"), metadata.get("dependencies")
+            ),
         }
 
         recommendations = self._recommendations(analysis)
@@ -169,7 +171,9 @@ class Archaeologist:
         end = min(line + span, len(lines))
         return [{"line": i + 1, "content": lines[i]} for i in range(start, end)]
 
-    def _review_dependencies(self, file: str | None) -> list[dict[str, Any]]:
+    def _review_dependencies(
+        self, file: str | None, dep_info: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
         """Analyze imported modules from ``file`` for compatibility issues."""
 
         if not file or not Path(file).exists():
@@ -187,9 +191,18 @@ class Archaeologist:
             elif isinstance(node, ast.ImportFrom) and node.module:
                 deps.append(node.module.split(".")[0])
 
+        dep_info = dep_info or {}
         analyses: list[dict[str, Any]] = []
         for dep in sorted(set(deps)):
-            analyses.append(analyze_dependency(dep, source_path))
+            info = dep_info.get(dep)
+            new_version = None
+            if isinstance(info, dict):
+                new_version = info.get("new_version")
+            elif isinstance(info, str):
+                new_version = info
+            analyses.append(
+                analyze_dependency(dep, source_path, new_version=new_version)
+            )
         return analyses
 
     def _recommendations(self, analysis: dict[str, Any]) -> str:

--- a/autogpt/agents/archaeologist_dependency.py
+++ b/autogpt/agents/archaeologist_dependency.py
@@ -13,7 +13,8 @@ import requests
 def fetch_release_notes(package: str, version: str | None) -> str | None:
     """Fetch release notes for ``package`` at ``version`` from PyPI.
 
-    If fetching fails, ``None`` is returned.
+    ``version`` may be a not-yet-installed release that should be inspected
+    for compatibility. If fetching fails, ``None`` is returned.
     """
 
     if not version:
@@ -66,16 +67,19 @@ def scan_for_usage(source: Path, package: str) -> Set[str]:
     return usages
 
 
-def analyze_dependency(package: str, source: Path) -> Dict[str, Any]:
+def analyze_dependency(
+    package: str, source: Path, new_version: str | None = None
+) -> Dict[str, Any]:
     """Analyze ``package`` usage within ``source`` and check release notes."""
 
-    version: str | None = None
+    installed: str | None = None
     try:
-        version = metadata.version(package)
+        installed = metadata.version(package)
     except Exception:
         pass
 
-    release_notes = fetch_release_notes(package, version)
+    target_version = new_version or installed
+    release_notes = fetch_release_notes(package, target_version)
     usages = scan_for_usage(source, package)
 
     findings: list[str] = []
@@ -86,17 +90,20 @@ def analyze_dependency(package: str, source: Path) -> Dict[str, Any]:
             if name in lowered and any(
                 kw in lowered for kw in ["deprecated", "removed", "breaking"]
             ):
-                findings.append(f"{usage} may be incompatible with {package} {version}")
+                findings.append(
+                    f"{usage} may be incompatible with {package} {target_version}"
+                )
         if not findings and any(
             kw in lowered for kw in ["deprecated", "removed", "breaking"]
         ):
             findings.append(
-                f"{package} {version} release notes mention potential breaking changes"
+                f"{package} {target_version} release notes mention potential breaking changes"
             )
 
     return {
         "dependency": package,
-        "version": version,
+        "version": installed,
+        "new_version": new_version,
         "usages": sorted(usages),
         "release_notes": release_notes,
         "findings": findings,

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -95,3 +95,54 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
     assert blame["text"].startswith("^123")
     assert diag.details["context"][0]["content"].strip() == "import sample_dep"
     assert diag.details["dependencies"][0]["dependency"] == "sample_dep"
+
+
+def test_archaeologist_agent_uses_dependency_new_version(tmp_path: Path) -> None:
+    message_queue = MessageQueue()
+    Archaeologist(message_queue)
+
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    source_file = tmp_path / "mod.py"
+    source_file.write_text("import sample_dep\nsample_dep.old_func()\n")
+
+    def fake_run(
+        cmd: list[str], capture_output: bool = True, text: bool = True
+    ) -> SimpleNamespace:
+        if cmd[:2] == ["git", "blame"]:
+            return SimpleNamespace(stdout="^123 (user 2023-01-01 1) line\n", stderr="")
+        return SimpleNamespace(stdout="", stderr="")
+
+    called_versions: list[str | None] = []
+
+    def fake_fetch(package: str, version: str | None) -> str:
+        called_versions.append(version)
+        if version == "2.0":
+            return "old_func removed"
+        return ""
+
+    with (
+        patch.object(arch_module.subprocess, "run", side_effect=fake_run),
+        patch.object(dep_module.metadata, "version", return_value="1.0"),
+        patch.object(dep_module, "fetch_release_notes", side_effect=fake_fetch),
+    ):
+        payload = {
+            "plugin": "test_plugin",
+            "error_log": (
+                "Traceback (most recent call last):\n"
+                f'  File "{source_file}", line 2, in <module>'
+            ),
+            "dependencies": {"sample_dep": {"new_version": "2.0"}},
+        }
+        message_queue.publish(
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
+        )
+
+    assert len(received) == 1
+    dep_analysis = received[0].details["dependencies"][0]
+    assert called_versions == ["2.0"]
+    assert dep_analysis["new_version"] == "2.0"
+    assert any("sample_dep 2.0" in f for f in dep_analysis["findings"])

--- a/tests/unit/test_archaeologist_dependency.py
+++ b/tests/unit/test_archaeologist_dependency.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+# Avoid importing autogpt.agents package initializer with heavy dependencies
+agents_pkg = types.ModuleType("autogpt.agents")
+agents_pkg.__path__ = ["autogpt/agents"]
+sys.modules.setdefault("autogpt.agents", agents_pkg)
+
+dep = importlib.import_module("autogpt.agents.archaeologist_dependency")
+
+
+def test_analyze_dependency_uses_new_version(tmp_path: Path) -> None:
+    src = tmp_path / "mod.py"
+    src.write_text("import sample_dep\nsample_dep.old_func()\n")
+
+    called: list[str | None] = []
+
+    def fake_fetch(package: str, version: str | None) -> str:
+        called.append(version)
+        if version == "2.0":
+            return "old_func removed"
+        return ""
+
+    with (
+        patch.object(dep.metadata, "version", return_value="1.0"),
+        patch.object(dep, "fetch_release_notes", side_effect=fake_fetch),
+    ):
+        result = dep.analyze_dependency("sample_dep", src, new_version="2.0")
+
+    assert called == ["2.0"]
+    assert result["version"] == "1.0"
+    assert result["new_version"] == "2.0"
+    assert any("sample_dep 2.0" in f for f in result["findings"])


### PR DESCRIPTION
## Summary
- allow dependency ISSUE_DETECTED events to specify a new version
- analyze release notes for the upcoming version to flag incompatibilities
- test dependency analysis with new-version metadata

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/agents/archaeologist_dependency.py autogpt/agents/archaeologist.py tests/unit/test_archaeologist_dependency.py tests/unit/test_archaeologist_agent.py`
- `PYTHONPATH=/workspace/AutoGPT-0.4.7 pytest /tmp/test_run/test_archaeologist_dependency.py /tmp/test_run/test_archaeologist_agent.py -k test_archaeologist_agent_uses_dependency_new_version -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c2eed81c832fab815e0137125f70