### PR TITLE
Use pytest exit codes for test command and developer logic

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -77,10 +77,7 @@ class TDDDeveloper:
         create_test_file(str(test_file), test_content, self.agent)
 
         initial_result = run_tests(str(test_file), self.agent)
-        if (
-            initial_result.get("failures", 0) == 0
-            and initial_result.get("errors", 0) == 0
-        ):
+        if initial_result.get("exit_code", 1) == 0:
             return
 
         fixes: list[dict[str, str]] = []
@@ -96,7 +93,7 @@ class TDDDeveloper:
                     write_to_file(str(file_path), new_content, self.agent)
 
             result = run_tests(repo_path, self.agent)
-            if result.get("failures", 0) == 0 and result.get("errors", 0) == 0:
+            if result.get("exit_code", 1) == 0:
                 git_commit(repo_path, f"Fix issue {issue_id}", self.agent)
                 try:
                     commit_hash = Repo(repo_path).head.commit.hexsha

--- a/autogpt/commands/testing.py
+++ b/autogpt/commands/testing.py
@@ -4,6 +4,7 @@ COMMAND_CATEGORY = "testing"
 COMMAND_CATEGORY_TITLE = "Testing"
 
 import io
+import json
 import os
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -33,41 +34,42 @@ from .file_operations import write_to_file
 def run_tests(path: str, agent: Agent) -> Dict[str, Any]:
     """Run tests using pytest and return structured results.
 
+    The function relies on ``pytest-json-report`` to obtain a machine readable
+    summary of the test run. If the plugin is unavailable, the exit code of
+    ``pytest`` is used to infer the outcome.
+
     Args:
         path: Path to the tests to run.
         agent: The Agent running the command.
 
     Returns:
-        Dict with keys ``successes``, ``failures``, ``errors`` and ``logs``.
+        Dictionary with keys ``status``, ``exit_code``, ``successes``,
+        ``failures``, ``errors`` and ``logs``.
     """
 
-    class ResultAggregator:
-        """Pytest plugin to aggregate test results."""
-
-        def __init__(self) -> None:
-            self.passed = 0
-            self.failed = 0
-            self.errors = 0
-
-        def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:  # type: ignore[override]
-            if report.when == "call":
-                if report.passed:
-                    self.passed += 1
-                elif report.failed:
-                    self.failed += 1
-            elif report.failed:
-                self.errors += 1
-
-    aggregator = ResultAggregator()
     output_buffer = io.StringIO()
+    report_file = Path(agent.config.workspace_path) / ".pytest_report.json"
 
     try:
         prev_cwd = os.getcwd()
         os.chdir(agent.config.workspace_path)
         with redirect_stdout(output_buffer), redirect_stderr(output_buffer):
-            pytest.main([path], plugins=[aggregator])
+            exit_code = pytest.main(
+                [path, "--json-report", f"--json-report-file={report_file}"]
+            )
+
+        summary: Dict[str, int] = {}
+        if report_file.is_file():
+            try:
+                with report_file.open("r", encoding="utf-8") as f:
+                    data = json.load(f)
+                summary = data.get("summary", {})
+            except Exception:  # pragma: no cover - best effort
+                summary = {}
     except Exception as e:  # pragma: no cover - defensive programming
         return {
+            "status": "error",
+            "exit_code": 1,
             "successes": 0,
             "failures": 0,
             "errors": 1,
@@ -75,11 +77,25 @@ def run_tests(path: str, agent: Agent) -> Dict[str, Any]:
         }
     finally:
         os.chdir(prev_cwd)
+        try:
+            report_file.unlink()
+        except FileNotFoundError:
+            pass
+
+    successes = int(summary.get("passed", 0))
+    failures = int(summary.get("failed", 0))
+    errors = int(summary.get("errors", summary.get("error", 0)))
+    if exit_code == 2 and failures == 0 and errors == 0:
+        errors = 1
+
+    status = "passed" if exit_code == 0 else "failed"
 
     return {
-        "successes": aggregator.passed,
-        "failures": aggregator.failed,
-        "errors": aggregator.errors,
+        "status": status,
+        "exit_code": exit_code,
+        "successes": successes,
+        "failures": failures,
+        "errors": errors,
         "logs": output_buffer.getvalue(),
     }
 

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -62,6 +62,8 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
         qa_module,
         "run_tests",
         return_value={
+            "status": "passed",
+            "exit_code": 0,
             "successes": 1,
             "failures": 0,
             "errors": 0,

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -46,9 +46,30 @@ def test_tdd_developer_handles_diagnosis(
     run = mocker.patch(
         "autogpt.agents.tdd_developer.run_tests",
         side_effect=[
-            {"successes": 0, "failures": 1, "errors": 0, "logs": "1 failed"},
-            {"successes": 1, "failures": 1, "errors": 0, "logs": "1 failed"},
-            {"successes": 2, "failures": 0, "errors": 0, "logs": "2 passed"},
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "successes": 0,
+                "failures": 1,
+                "errors": 0,
+                "logs": "1 failed",
+            },
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "successes": 1,
+                "failures": 1,
+                "errors": 0,
+                "logs": "1 failed",
+            },
+            {
+                "status": "passed",
+                "exit_code": 0,
+                "successes": 2,
+                "failures": 0,
+                "errors": 0,
+                "logs": "2 passed",
+            },
         ],
     )
     commit = mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
@@ -111,8 +132,20 @@ def test_tdd_developer_generates_repro_test(
     mocker.patch(
         "autogpt.agents.tdd_developer.run_tests",
         side_effect=[
-            {"successes": 0, "failures": 1, "errors": 0},
-            {"successes": 0, "failures": 1, "errors": 0},
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "successes": 0,
+                "failures": 1,
+                "errors": 0,
+            },
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "successes": 0,
+                "failures": 1,
+                "errors": 0,
+            },
         ],
     )
 

--- a/tests/unit/test_tdd_developer_agent.py
+++ b/tests/unit/test_tdd_developer_agent.py
@@ -83,8 +83,22 @@ def test_tdd_developer_agent_flow(tmp_path, mocker):
         tdd_module,
         "run_tests",
         side_effect=[
-            {"successes": 0, "failures": 1, "errors": 0, "logs": "1 failed"},
-            {"successes": 1, "failures": 0, "errors": 0, "logs": "1 passed"},
+            {
+                "status": "failed",
+                "exit_code": 1,
+                "successes": 0,
+                "failures": 1,
+                "errors": 0,
+                "logs": "1 failed",
+            },
+            {
+                "status": "passed",
+                "exit_code": 0,
+                "successes": 1,
+                "failures": 0,
+                "errors": 0,
+                "logs": "1 passed",
+            },
         ],
     )
     commit = mocker.patch.object(tdd_module, "git_commit", return_value="")

--- a/tests/unit/test_testing_command.py
+++ b/tests/unit/test_testing_command.py
@@ -10,6 +10,8 @@ def test_run_tests_success(workspace, agent: Agent):
         f.write("def test_example():\n    assert True\n")
 
     result = run_tests(str(test_file), agent=agent)
+    assert result["exit_code"] == 0
+    assert result["status"] == "passed"
     assert result["successes"] == 1
     assert result["failures"] == 0
     assert result["errors"] == 0


### PR DESCRIPTION
## Summary
- build `run_tests` around pytest's JSON report and exit codes to return structured results
- drive `TDDDeveloper` decisions using exit codes from test runs
- adapt unit tests for new test result structure

## Testing
- `pytest tests/unit/test_testing_command.py tests/unit/test_tdd_developer.py tests/unit/test_tdd_developer_agent.py tests/unit/test_qa_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6891c51743bc832f90077b3314fb73b2