### PR TITLE
Handle test and deployment failures

### DIFF
--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -16,9 +16,11 @@ from autogpt.event_bus import (
     CODE_FIX_PROPOSED,
     ApprovalGranted,
     CodeFixProposed,
+    DeploymentFailed,
     HumanApprovalRequired,
     IssueResolved,
     MessageQueue,
+    TestsFailed,
 )
 
 
@@ -51,14 +53,28 @@ class QAAgent:
             git_checkout(tmp_repo_path, branch, self.agent)
             test_result = run_tests(tmp_repo_path, self.agent)
 
-        self.message_queue.publish(
-            HumanApprovalRequired(
-                branch_name=branch,
-                test_output=test_result["logs"],
-                summary=event.summary,
-                source_agent="qa_agent",
+        if (
+            test_result.get("status") == "passed"
+            and test_result.get("failures", 0) == 0
+            and test_result.get("errors", 0) == 0
+        ):
+            self.message_queue.publish(
+                HumanApprovalRequired(
+                    branch_name=branch,
+                    test_output=test_result["logs"],
+                    summary=event.summary,
+                    source_agent="qa_agent",
+                )
             )
-        )
+        else:
+            self.message_queue.publish(
+                TestsFailed(
+                    branch_name=branch,
+                    test_output=test_result.get("logs", ""),
+                    summary=event.summary,
+                    source_agent="qa_agent",
+                )
+            )
 
     def _on_approval_granted(self, event: ApprovalGranted) -> None:
         """Handle an ``APPROVAL_GRANTED`` event."""
@@ -77,9 +93,23 @@ class QAAgent:
         repo.git.merge(branch)
 
         try:
-            subprocess.run(["bash", "scripts/deploy.sh"], cwd=repo_path, check=False)
+            result = subprocess.run(
+                ["bash", "scripts/deploy.sh"], cwd=repo_path, check=False
+            )
         except Exception:
-            pass
+            result = subprocess.CompletedProcess([], returncode=1)  # type: ignore[arg-type]
+
+        if result.returncode != 0:
+            self.message_queue.publish(
+                DeploymentFailed(
+                    branch_name=branch,
+                    commit_hash=event.commit_hash,
+                    summary=event.summary,
+                    return_code=result.returncode,
+                    source_agent="qa_agent",
+                )
+            )
+            return
 
         self.message_queue.publish(
             IssueResolved(

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -2,23 +2,26 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
 from .message_types import (
     APPROVAL_GRANTED,
     CODE_FIX_PROPOSED,
+    DEPLOYMENT_FAILED,
     DIAGNOSIS_COMPLETE,
     HUMAN_APPROVAL_REQUIRED,
     ISSUE_DETECTED,
     ISSUE_RESOLVED,
+    TESTS_FAILED,
     ApprovalGranted,
     CodeFixProposed,
+    DeploymentFailed,
     DiagnosisComplete,
     EventMessage,
     HumanApprovalRequired,
     IssueResolved,
+    TestsFailed,
 )
 
 
@@ -115,6 +118,23 @@ class EventBus:
                     source_agent=source_agent,
                     timestamp=ts,
                 )
+            elif et == TESTS_FAILED and isinstance(payload_obj, dict):
+                yield TestsFailed(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    test_output=str(payload_obj.get("test_output", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
+            elif et == DEPLOYMENT_FAILED and isinstance(payload_obj, dict):
+                yield DeploymentFailed(
+                    branch_name=str(payload_obj.get("branch_name", "")),
+                    commit_hash=str(payload_obj.get("commit_hash", "")),
+                    summary=str(payload_obj.get("summary", "")),
+                    return_code=int(payload_obj.get("return_code", 0)),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
             else:
                 yield EventMessage(
                     event_type=et,
@@ -133,12 +153,16 @@ __all__ = [
     "DiagnosisComplete",
     "CodeFixProposed",
     "HumanApprovalRequired",
+    "TestsFailed",
     "ApprovalGranted",
     "IssueResolved",
+    "DeploymentFailed",
     "ISSUE_DETECTED",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
     "HUMAN_APPROVAL_REQUIRED",
+    "TESTS_FAILED",
     "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
+    "DEPLOYMENT_FAILED",
 ]

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -37,6 +37,12 @@ ISSUE_RESOLVED = "ISSUE_RESOLVED"
 ISSUE_DETECTED = "ISSUE_DETECTED"
 """Event type emitted when a plugin issue is detected."""
 
+TESTS_FAILED = "TESTS_FAILED"
+"""Event type emitted when verification tests fail."""
+
+DEPLOYMENT_FAILED = "DEPLOYMENT_FAILED"
+"""Event type emitted when deployment fails."""
+
 
 @dataclass(kw_only=True)
 class DiagnosisComplete(EventMessage):
@@ -105,6 +111,24 @@ class HumanApprovalRequired(EventMessage):
 
 
 @dataclass(kw_only=True)
+class TestsFailed(EventMessage):
+    """Schema for :data:`TESTS_FAILED` events."""
+
+    branch_name: str
+    test_output: str
+    summary: str
+    event_type: str = field(init=False, default=TESTS_FAILED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "test_output": self.test_output,
+            "summary": self.summary,
+        }
+
+
+@dataclass(kw_only=True)
 class ApprovalGranted(EventMessage):
     """Schema for :data:`APPROVAL_GRANTED` events.
 
@@ -152,17 +176,41 @@ class IssueResolved(EventMessage):
         }
 
 
+@dataclass(kw_only=True)
+class DeploymentFailed(EventMessage):
+    """Schema for :data:`DEPLOYMENT_FAILED` events."""
+
+    branch_name: str
+    commit_hash: str
+    summary: str
+    return_code: int
+    event_type: str = field(init=False, default=DEPLOYMENT_FAILED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "branch_name": self.branch_name,
+            "commit_hash": self.commit_hash,
+            "summary": self.summary,
+            "return_code": self.return_code,
+        }
+
+
 __all__ = [
     "EventMessage",
     "DiagnosisComplete",
     "CodeFixProposed",
     "HumanApprovalRequired",
+    "TestsFailed",
     "ApprovalGranted",
     "IssueResolved",
+    "DeploymentFailed",
     "ISSUE_DETECTED",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
     "HUMAN_APPROVAL_REQUIRED",
+    "TESTS_FAILED",
     "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
+    "DEPLOYMENT_FAILED",
 ]

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -10,8 +10,10 @@ from autogpt.event_bus import (
     CODE_FIX_PROPOSED,
     ApprovalGranted,
     CodeFixProposed,
+    DeploymentFailed,
     HumanApprovalRequired,
     IssueResolved,
+    TestsFailed,
 )
 
 # Avoid importing autogpt.agents package initializer with heavy dependencies
@@ -26,16 +28,16 @@ class Agent:  # minimal stub to satisfy imports
     pass
 
 
-agent_stub.Agent = Agent
+agent_stub.Agent = Agent  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.agents.agent", agent_stub)
 
 testing_stub = types.ModuleType("autogpt.commands.testing")
-testing_stub.run_tests = lambda *a, **k: ""
+testing_stub.run_tests = lambda *a, **k: ""  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.commands.testing", testing_stub)
 
 git_ops_stub = types.ModuleType("autogpt.commands.git_operations")
-git_ops_stub.git_checkout = lambda *a, **k: ""
-git_ops_stub.git_clone = lambda *a, **k: ""
+git_ops_stub.git_checkout = lambda *a, **k: ""  # type: ignore[attr-defined]
+git_ops_stub.git_clone = lambda *a, **k: ""  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.commands.git_operations", git_ops_stub)
 
 qa_module = importlib.import_module("autogpt.agents.qa_agent")
@@ -81,7 +83,9 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     remotes_mock.origin = origin_mock
     repo_mock.remotes = remotes_mock
     mocker.patch.object(qa_module, "Repo", return_value=repo_mock)
-    subprocess_run = mocker.patch.object(qa_module.subprocess, "run")
+    subprocess_run = mocker.patch.object(
+        qa_module.subprocess, "run", return_value=mocker.MagicMock(returncode=0)
+    )
 
     clone_dir = tmp_path / "clone"
     mocker.patch.object(
@@ -96,7 +100,9 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     event = CodeFixProposed(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
     on_code_fix_proposed(event)
 
-    git_clone.assert_called_once_with("https://example.com/repo.git", str(clone_dir), agent)
+    git_clone.assert_called_once_with(
+        "https://example.com/repo.git", str(clone_dir), agent
+    )
     git_checkout.assert_called_once_with(str(clone_dir), "fix/123", agent)
     run_tests.assert_called_once_with(str(clone_dir), agent)
     message_queue.publish.assert_called_once()
@@ -124,3 +130,139 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     assert resolved_event.branch_name == "fix/123"
     assert resolved_event.commit_hash == "abc"
     assert resolved_event.summary == "Fix bug"
+
+
+def test_qa_agent_handles_failed_tests(tmp_path: Path, mocker: MockerFixture) -> None:
+    message_queue = mocker.Mock(spec=["subscribe", "publish"])
+    agent = mocker.Mock()
+    agent.config.workspace_path = str(tmp_path)
+
+    QAAgent(agent=agent, message_queue=message_queue)
+
+    callbacks = {
+        call.args[0]: call.args[1] for call in message_queue.subscribe.call_args_list
+    }
+    on_code_fix_proposed = callbacks[CODE_FIX_PROPOSED]
+
+    git_clone = mocker.patch.object(qa_module, "git_clone")
+    git_checkout = mocker.patch.object(qa_module, "git_checkout")
+    run_tests = mocker.patch.object(
+        qa_module,
+        "run_tests",
+        return_value={
+            "status": "failed",
+            "exit_code": 1,
+            "successes": 0,
+            "failures": 1,
+            "errors": 0,
+            "logs": "tests failed",
+        },
+    )
+    repo_mock = mocker.MagicMock()
+    origin_mock = mocker.MagicMock()
+    origin_mock.url = "https://example.com/repo.git"
+    remotes_mock = mocker.MagicMock()
+    remotes_mock.origin = origin_mock
+    repo_mock.remotes = remotes_mock
+    mocker.patch.object(qa_module, "Repo", return_value=repo_mock)
+    mocker.patch.object(qa_module.subprocess, "run")
+
+    clone_dir = tmp_path / "clone"
+    mocker.patch.object(
+        qa_module.tempfile,
+        "TemporaryDirectory",
+        return_value=mocker.MagicMock(
+            __enter__=mocker.MagicMock(return_value=str(clone_dir)),
+            __exit__=mocker.MagicMock(return_value=None),
+        ),
+    )
+
+    event = CodeFixProposed(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
+    on_code_fix_proposed(event)
+
+    git_clone.assert_called_once_with(
+        "https://example.com/repo.git", str(clone_dir), agent
+    )
+    git_checkout.assert_called_once_with(str(clone_dir), "fix/123", agent)
+    run_tests.assert_called_once_with(str(clone_dir), agent)
+    message_queue.publish.assert_called_once()
+    published_event = message_queue.publish.call_args[0][0]
+    assert isinstance(published_event, TestsFailed)
+    assert repo_mock.git.merge.call_count == 0
+
+
+def test_qa_agent_handles_deployment_failure(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    message_queue = mocker.Mock(spec=["subscribe", "publish"])
+    agent = mocker.Mock()
+    agent.config.workspace_path = str(tmp_path)
+
+    QAAgent(agent=agent, message_queue=message_queue)
+
+    callbacks = {
+        call.args[0]: call.args[1] for call in message_queue.subscribe.call_args_list
+    }
+    on_code_fix_proposed = callbacks[CODE_FIX_PROPOSED]
+    on_approval_granted = callbacks[APPROVAL_GRANTED]
+
+    mocker.patch.object(qa_module, "git_clone")
+    mocker.patch.object(qa_module, "git_checkout")
+    mocker.patch.object(
+        qa_module,
+        "run_tests",
+        return_value={
+            "status": "passed",
+            "exit_code": 0,
+            "successes": 1,
+            "failures": 0,
+            "errors": 0,
+            "logs": "tests passed",
+        },
+    )
+    repo_mock = mocker.MagicMock()
+    repo_mock.git.checkout.return_value = ""
+    repo_mock.git.merge.return_value = ""
+    origin_mock = mocker.MagicMock()
+    origin_mock.url = "https://example.com/repo.git"
+    remotes_mock = mocker.MagicMock()
+    remotes_mock.origin = origin_mock
+    repo_mock.remotes = remotes_mock
+    mocker.patch.object(qa_module, "Repo", return_value=repo_mock)
+    subprocess_run = mocker.patch.object(
+        qa_module.subprocess,
+        "run",
+        return_value=mocker.MagicMock(returncode=1),
+    )
+
+    clone_dir = tmp_path / "clone"
+    mocker.patch.object(
+        qa_module.tempfile,
+        "TemporaryDirectory",
+        return_value=mocker.MagicMock(
+            __enter__=mocker.MagicMock(return_value=str(clone_dir)),
+            __exit__=mocker.MagicMock(return_value=None),
+        ),
+    )
+
+    event = CodeFixProposed(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
+    on_code_fix_proposed(event)
+
+    approval_event = ApprovalGranted(
+        branch_name="fix/123", commit_hash="abc", summary="Fix bug"
+    )
+    on_approval_granted(approval_event)
+
+    repo_mock.git.checkout.assert_called_once_with("main")
+    repo_mock.git.merge.assert_called_once_with("fix/123")
+    subprocess_run.assert_called_once_with(
+        ["bash", "scripts/deploy.sh"], cwd=str(tmp_path), check=False
+    )
+    message_queue.publish.assert_called()
+    assert all(
+        not isinstance(call.args[0], IssueResolved)
+        for call in message_queue.publish.call_args_list
+    )
+    assert len(message_queue.publish.call_args_list) == 2
+    published_event = message_queue.publish.call_args_list[-1][0][0]
+    assert isinstance(published_event, DeploymentFailed)


### PR DESCRIPTION
## Summary
- require clean test run before seeking approval and emit `TestsFailed` on failing suites
- publish `DeploymentFailed` when deployment script returns non-zero
- add unit tests covering failed tests and deployments

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/agents/qa_agent.py autogpt/event_bus/__init__.py autogpt/event_bus/message_types.py tests/unit/test_qa_agent.py`
- `pytest --noconftest tests/unit/test_qa_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ca108ff8832fba4a74cc0e937845