### PR TITLE
Include diff in HumanApprovalRequired events

### DIFF
--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -44,17 +44,21 @@ class QAAgent:
         if not branch or not repo_path:
             return
 
-        repo_url = Repo(repo_path).remotes.origin.url
+        repo = Repo(repo_path)
+        repo_url = repo.remotes.origin.url
 
         with tempfile.TemporaryDirectory() as tmp_repo_path:
             git_clone(repo_url, tmp_repo_path, self.agent)
             git_checkout(tmp_repo_path, branch, self.agent)
             test_result = run_tests(tmp_repo_path, self.agent)
 
+        diff = repo.git.diff("main", branch)
+
         self.message_queue.publish(
             HumanApprovalRequired(
                 branch_name=branch,
                 test_output=test_result["logs"],
+                diff=diff,
                 summary=event.summary,
                 source_agent="qa_agent",
             )

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -95,6 +95,7 @@ class EventBus:
                 yield HumanApprovalRequired(
                     branch_name=str(payload_obj.get("branch_name", "")),
                     test_output=str(payload_obj.get("test_output", "")),
+                    diff=str(payload_obj.get("diff", "")),
                     summary=str(payload_obj.get("summary", "")),
                     source_agent=source_agent,
                     timestamp=ts,

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -87,11 +87,13 @@ class HumanApprovalRequired(EventMessage):
     Expected payload fields:
         branch_name: Branch containing the proposed fix.
         test_output: Output from the verification test run.
+        diff: Diff between ``main`` and the proposed branch.
         summary: Short description of the proposed fix.
     """
 
     branch_name: str
     test_output: str
+    diff: str
     summary: str
     event_type: str = field(init=False, default=HUMAN_APPROVAL_REQUIRED)
     payload: dict[str, Any] | str | None = field(init=False)
@@ -100,6 +102,7 @@ class HumanApprovalRequired(EventMessage):
         self.payload = {
             "branch_name": self.branch_name,
             "test_output": self.test_output,
+            "diff": self.diff,
             "summary": self.summary,
         }
 

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -26,16 +26,16 @@ class Agent:  # minimal stub to satisfy imports
     pass
 
 
-agent_stub.Agent = Agent
+agent_stub.Agent = Agent  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.agents.agent", agent_stub)
 
 testing_stub = types.ModuleType("autogpt.commands.testing")
-testing_stub.run_tests = lambda *a, **k: ""
+testing_stub.run_tests = lambda *a, **k: ""  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.commands.testing", testing_stub)
 
 git_ops_stub = types.ModuleType("autogpt.commands.git_operations")
-git_ops_stub.git_checkout = lambda *a, **k: ""
-git_ops_stub.git_clone = lambda *a, **k: ""
+git_ops_stub.git_checkout = lambda *a, **k: ""  # type: ignore[attr-defined]
+git_ops_stub.git_clone = lambda *a, **k: ""  # type: ignore[attr-defined]
 sys.modules.setdefault("autogpt.commands.git_operations", git_ops_stub)
 
 qa_module = importlib.import_module("autogpt.agents.qa_agent")
@@ -75,6 +75,7 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     repo_mock = mocker.MagicMock()
     repo_mock.git.checkout.return_value = ""
     repo_mock.git.merge.return_value = ""
+    repo_mock.git.diff.return_value = "diff output"
     origin_mock = mocker.MagicMock()
     origin_mock.url = "https://example.com/repo.git"
     remotes_mock = mocker.MagicMock()
@@ -96,14 +97,18 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     event = CodeFixProposed(branch_name="fix/123", commit_hash="abc", summary="Fix bug")
     on_code_fix_proposed(event)
 
-    git_clone.assert_called_once_with("https://example.com/repo.git", str(clone_dir), agent)
+    git_clone.assert_called_once_with(
+        "https://example.com/repo.git", str(clone_dir), agent
+    )
     git_checkout.assert_called_once_with(str(clone_dir), "fix/123", agent)
     run_tests.assert_called_once_with(str(clone_dir), agent)
+    repo_mock.git.diff.assert_called_once_with("main", "fix/123")
     message_queue.publish.assert_called_once()
     published_event = message_queue.publish.call_args[0][0]
     assert isinstance(published_event, HumanApprovalRequired)
     assert published_event.branch_name == "fix/123"
     assert published_event.test_output == "tests passed"
+    assert published_event.diff == "diff output"
     assert published_event.summary == "Fix bug"
 
     message_queue.publish.reset_mock()


### PR DESCRIPTION
## Summary
- compute main vs branch diff before publishing HumanApprovalRequired
- extend HumanApprovalRequired schema with `diff`
- assert diff propagation in QA agent tests

## Testing
- `pre-commit run --files autogpt/event_bus/message_types.py autogpt/event_bus/__init__.py autogpt/agents/qa_agent.py tests/unit/test_qa_agent.py`
- `pytest tests/unit/test_qa_agent.py::test_qa_agent_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ca0b9a6c832f8fb840678e6cdcb3