### PR TITLE
Include diff in human approval events

### DIFF
--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -46,7 +46,8 @@ class QAAgent:
         if not branch or not repo_path:
             return
 
-        repo_url = Repo(repo_path).remotes.origin.url
+        repo = Repo(repo_path)
+        repo_url = repo.remotes.origin.url
 
         with tempfile.TemporaryDirectory() as tmp_repo_path:
             git_clone(repo_url, tmp_repo_path, self.agent)
@@ -58,11 +59,13 @@ class QAAgent:
             and test_result.get("failures", 0) == 0
             and test_result.get("errors", 0) == 0
         ):
+            diff = repo.git.diff("main", branch)
             self.message_queue.publish(
                 HumanApprovalRequired(
                     branch_name=branch,
                     test_output=test_result["logs"],
                     summary=event.summary,
+                    diff=diff,
                     source_agent="qa_agent",
                 )
             )

--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -99,6 +99,7 @@ class EventBus:
                     branch_name=str(payload_obj.get("branch_name", "")),
                     test_output=str(payload_obj.get("test_output", "")),
                     summary=str(payload_obj.get("summary", "")),
+                    diff=str(payload_obj.get("diff", "")),
                     source_agent=source_agent,
                     timestamp=ts,
                 )

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -94,11 +94,13 @@ class HumanApprovalRequired(EventMessage):
         branch_name: Branch containing the proposed fix.
         test_output: Output from the verification test run.
         summary: Short description of the proposed fix.
+        diff: Diff between ``main`` and the proposed branch.
     """
 
     branch_name: str
     test_output: str
     summary: str
+    diff: str
     event_type: str = field(init=False, default=HUMAN_APPROVAL_REQUIRED)
     payload: dict[str, Any] | str | None = field(init=False)
 
@@ -107,6 +109,7 @@ class HumanApprovalRequired(EventMessage):
             "branch_name": self.branch_name,
             "test_output": self.test_output,
             "summary": self.summary,
+            "diff": self.diff,
         }
 
 

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -77,6 +77,7 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     repo_mock = mocker.MagicMock()
     repo_mock.git.checkout.return_value = ""
     repo_mock.git.merge.return_value = ""
+    repo_mock.git.diff.return_value = "diff content"
     origin_mock = mocker.MagicMock()
     origin_mock.url = "https://example.com/repo.git"
     remotes_mock = mocker.MagicMock()
@@ -111,6 +112,7 @@ def test_qa_agent_flow(tmp_path: Path, mocker: MockerFixture) -> None:
     assert published_event.branch_name == "fix/123"
     assert published_event.test_output == "tests passed"
     assert published_event.summary == "Fix bug"
+    assert published_event.diff == "diff content"
 
     message_queue.publish.reset_mock()
 


### PR DESCRIPTION
## Summary
- compute main vs branch diff before emitting `HumanApprovalRequired`
- add `diff` field to `HumanApprovalRequired` schema and event bus
- assert diff propagation in QA agent unit tests

## Testing
- `pytest tests/unit/test_qa_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6891cd5c1488832fabe12bed03a19886