### PR TITLE
feat(dashboard): persist issue events

### DIFF
--- a/autogpt/dashboard/app.py
+++ b/autogpt/dashboard/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from pathlib import Path
 from queue import Queue
 from threading import Lock
@@ -28,11 +29,44 @@ EVENT_TYPES = [
     ISSUE_RESOLVED,
 ]
 
+EVENT_STAGE_MAPPING = {
+    "ISSUE_DETECTED": "detected",
+    DIAGNOSIS_COMPLETE: "diagnosed",
+    CODE_FIX_PROPOSED: "fix_proposed",
+    HUMAN_APPROVAL_REQUIRED: "awaiting_approval",
+    ISSUE_RESOLVED: "resolved",
+}
+
+
+def init_db(db_path: str | os.PathLike | None = None) -> sqlite3.Connection:
+    """Initialise and return a SQLite connection."""
+
+    db_path = Path(
+        db_path
+        or os.getenv("DASHBOARD_DB_PATH")
+        or Path(__file__).with_name("dashboard.db")
+    )
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events (
+            issue_id TEXT,
+            event_type TEXT,
+            payload TEXT,
+            source_agent TEXT,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
 
 def create_dashboard_app(
     message_queue: MessageQueue | None = None,
     *,
     auth_token: str | None = None,
+    db_path: str | os.PathLike | None = None,
 ) -> Flask:
     """Create a Flask app that serves a live event dashboard.
 
@@ -50,6 +84,33 @@ def create_dashboard_app(
     subscribers: list[Queue] = []
     issues: Dict[str, Dict[str, Any]] = {}
     lock = Lock()
+    db = init_db(db_path)
+
+    def _compute_stage(events: list[Dict[str, Any]]) -> str:
+        event_types = {e["event_type"] for e in events}
+        for et in reversed(EVENT_TYPES):
+            if et in event_types:
+                return EVENT_STAGE_MAPPING[et]
+        return "unknown"
+
+    def _load_events() -> None:
+        cur = db.execute(
+            "SELECT issue_id, event_type, payload, source_agent, timestamp FROM events ORDER BY timestamp"
+        )
+        for row in cur.fetchall():
+            data = {
+                "event_type": row[1],
+                "payload": json.loads(row[2]) if row[2] else {},
+                "source_agent": row[3],
+                "timestamp": row[4],
+                "issue_id": row[0],
+            }
+            issue = issues.setdefault(data["issue_id"], {"events": []})
+            issue["events"].append(data)
+            issue.update(data)
+            issue["stage"] = _compute_stage(issue["events"])
+
+    _load_events()
 
     def _authorized() -> bool:
         token = auth_token or os.getenv("DASHBOARD_TOKEN")
@@ -77,8 +138,21 @@ def create_dashboard_app(
             "issue_id": _issue_id(event),
         }
         with lock:
-            issues.setdefault(data["issue_id"], {"events": []})["events"].append(data)
-            issues[data["issue_id"]].update(data)
+            issue = issues.setdefault(data["issue_id"], {"events": []})
+            issue["events"].append(data)
+            issue.update(data)
+            issue["stage"] = _compute_stage(issue["events"])
+            db.execute(
+                "INSERT INTO events(issue_id, event_type, payload, source_agent, timestamp) VALUES (?, ?, ?, ?, ?)",
+                (
+                    data["issue_id"],
+                    data["event_type"],
+                    json.dumps(data["payload"]),
+                    data["source_agent"],
+                    data["timestamp"],
+                ),
+            )
+            db.commit()
         for q in list(subscribers):
             q.put(data)
 
@@ -124,10 +198,11 @@ def run_dashboard(
     host: str = "0.0.0.0",
     port: int = 8000,
     auth_token: str | None = None,
+    db_path: str | os.PathLike | None = None,
 ) -> None:
     """Run the dashboard web server."""
 
-    app = create_dashboard_app(message_queue, auth_token=auth_token)
+    app = create_dashboard_app(message_queue, auth_token=auth_token, db_path=db_path)
     app.run(host=host, port=port)
 
 

--- a/scripts/init_dashboard_db.py
+++ b/scripts/init_dashboard_db.py
@@ -1,0 +1,7 @@
+"""Initialize the dashboard event database."""
+
+from autogpt.dashboard.app import init_db
+
+
+if __name__ == "__main__":  # pragma: no cover - manual script
+    init_db()

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -13,7 +13,7 @@ from autogpt.event_bus import (
 
 def test_dashboard_tracks_events() -> None:
     mq = MessageQueue()
-    app = create_dashboard_app(mq)
+    app = create_dashboard_app(mq, db_path=":memory:")
     client = app.test_client()
 
     event = EventMessage(
@@ -28,11 +28,12 @@ def test_dashboard_tracks_events() -> None:
     assert data["42"]["event_type"] == "ISSUE_DETECTED"
     assert data["42"]["source_agent"] == "tester"
     assert data["42"]["timestamp"] == event.timestamp
+    assert data["42"]["stage"] == "detected"
 
 
 def test_auth_token_required() -> None:
     mq = MessageQueue()
-    app = create_dashboard_app(mq, auth_token="secret")
+    app = create_dashboard_app(mq, auth_token="secret", db_path=":memory:")
     client = app.test_client()
 
     assert client.get("/").status_code == 401
@@ -41,7 +42,7 @@ def test_auth_token_required() -> None:
 
 def test_dashboard_streams_events_and_updates_state() -> None:
     mq = MessageQueue()
-    app = create_dashboard_app(mq)
+    app = create_dashboard_app(mq, db_path=":memory:")
 
     with app.test_request_context("/stream"):
         resp = app.view_functions["stream"]()
@@ -76,11 +77,12 @@ def test_dashboard_streams_events_and_updates_state() -> None:
     issue = resp.get_json()["1"]
     assert issue["event_type"] == ISSUE_RESOLVED
     assert len(issue["events"]) == len(events)
+    assert issue["stage"] == "resolved"
 
 
 def test_dashboard_handles_missing_issue_id() -> None:
     mq = MessageQueue()
-    app = create_dashboard_app(mq)
+    app = create_dashboard_app(mq, db_path=":memory:")
     client = app.test_client()
 
     event = EventMessage(
@@ -97,7 +99,7 @@ def test_dashboard_handles_missing_issue_id() -> None:
 
 def test_stream_removes_disconnected_clients() -> None:
     mq = MessageQueue()
-    app = create_dashboard_app(mq)
+    app = create_dashboard_app(mq, db_path=":memory:")
     stream_func = app.view_functions["stream"]
     subscribers = next(
         cell.cell_contents
@@ -120,3 +122,23 @@ def test_stream_removes_disconnected_clients() -> None:
         next(gen)
         gen.close()
         assert len(subscribers) == 0
+
+
+def test_dashboard_persists_events(tmp_path) -> None:
+    db_file = tmp_path / "events.db"
+    mq = MessageQueue()
+    create_dashboard_app(mq, db_path=db_file)
+    event = EventMessage(
+        event_type="ISSUE_DETECTED",
+        payload={"issue_id": "7", "issue_type": "bug"},
+        source_agent="tester",
+    )
+    mq.publish(event)
+
+    # New app instance using the same database should load the event
+    mq2 = MessageQueue()
+    app2 = create_dashboard_app(mq2, db_path=db_file)
+    client = app2.test_client()
+    data = client.get("/issues").get_json()
+    assert data["7"]["stage"] == "detected"
+    assert len(data["7"]["events"]) == 1


### PR DESCRIPTION
## Summary
- persist dashboard events to SQLite and expose lifecycle stage mapping
- add script to initialise dashboard database
- test dashboard state persistence and stage reporting

## Testing
- `ruff check autogpt/dashboard/app.py tests/unit/test_dashboard.py scripts/init_dashboard_db.py`
- `pytest tests/unit/test_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d07634ec832fab33bcdb83c3b447