### PR TITLE
feat: add librarian agent wrapper

### DIFF
--- a/autogpt/skills/__init__.py
+++ b/autogpt/skills/__init__.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 from autogpt.config import ConfigBuilder
 
 from .library import Skill, SkillLibrary
+from .librarian import LibrarianAgent
 from .vector_db import ChromaVectorDB, MemoryVectorDB, VectorDBProvider
 
 _default_library: SkillLibrary | None = None
@@ -116,6 +117,7 @@ def search(query: str, top_k: int = 5) -> List[Skill]:
 __all__ = [
     "Skill",
     "SkillLibrary",
+    "LibrarianAgent",
     "VectorDBProvider",
     "MemoryVectorDB",
     "ChromaVectorDB",

--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Agent wrapper around :class:`SkillLibrary` for managing skills."""
 
 from dataclasses import asdict
+import shutil
 from pathlib import Path
 from typing import List
 
@@ -39,10 +40,20 @@ class LibrarianAgent:
         try:
             metadata = SkillMetadata(**skill_metadata)
         except TypeError:
+            # Provided metadata does not match the expected schema
             return False
 
+        source = Path(skill_code_path)
+        if not source.is_file():
+            return False
+
+        # Copy the code into the skill library directory
+        dest_dir = self.skill_library.storage_path / f"{metadata.skill_name}_{metadata.version}"
         try:
-            code = Path(skill_code_path).read_text(encoding="utf-8")
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest_file = dest_dir / "main.py"
+            shutil.copy2(source, dest_file)
+            code = dest_file.read_text(encoding="utf-8")
         except OSError:
             return False
 
@@ -54,6 +65,11 @@ class LibrarianAgent:
                 parameters=metadata.parameters,
                 description=metadata.description,
                 tags=metadata.tags,
+                dependencies_file=metadata.dependencies_file,
+                entry_point=metadata.entry_point,
+                return_type=metadata.return_type,
+                author_agent=metadata.author_agent,
+                creation_timestamp=metadata.creation_timestamp,
             )
             return True
         except Exception:

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from autogpt.config import Config
-from autogpt.skills.librarian import LibrarianAgent
+from autogpt.skills import LibrarianAgent
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add `LibrarianAgent` wrapper around `SkillLibrary`
- expose `LibrarianAgent` via skills package and CLI

## Testing
- `pytest tests/unit/test_skill_library.py::test_skill_library_save_and_search -q`
- `pytest -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'mlx')*


------
https://chatgpt.com/codex/tasks/task_e_6891d189db30832fb04452f05f8e1ef6