### PR TITLE
Forward all skill metadata in librarian

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -54,6 +54,11 @@ class LibrarianAgent:
                 parameters=metadata.parameters,
                 description=metadata.description,
                 tags=metadata.tags,
+                dependencies_file=metadata.dependencies_file,
+                entry_point=metadata.entry_point,
+                return_type=metadata.return_type,
+                author_agent=metadata.author_agent,
+                creation_timestamp=metadata.creation_timestamp,
             )
             return True
         except Exception:

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autogpt.config import Config
+from autogpt.skills.librarian import LibrarianAgent
+
+
+def test_add_skill_persists_full_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = LibrarianAgent(Config())
+    agent.skill_library.storage_path = tmp_path
+    monkeypatch.setattr(
+        "autogpt.skills.library.get_embedding",
+        lambda _text, _config: [0.0, 0.0, 0.0],
+    )
+
+    code_file = tmp_path / "skill.py"
+    code_file.write_text(
+        """def run():
+    return 'hello'
+"""
+    )
+
+    metadata = {
+        "skill_name": "test_skill",
+        "version": "1.0",
+        "description": "Test skill",
+        "tags": ["test"],
+        "parameters": {"param": "value"},
+        "dependencies_file": "requirements.txt",
+        "entry_point": "main:run",
+        "return_type": "str",
+        "author_agent": "tester",
+        "creation_timestamp": "2024-01-01T00:00:00Z",
+    }
+
+    assert agent.add_skill(metadata, str(code_file))
+
+    skill_json = tmp_path / "test_skill_1.0" / "skill.json"
+    with skill_json.open("r", encoding="utf-8") as f:
+        stored = json.load(f)
+
+    assert stored == metadata


### PR DESCRIPTION
## Summary
- forward all SkillMetadata fields when LibrarianAgent adds a skill to the library
- add regression test ensuring LibrarianAgent persists full metadata to `skill.json`

## Testing
- `pre-commit run --files autogpt/skills/librarian.py tests/unit/test_librarian_agent.py` (skipping autoflake,pytest-check)
- `pytest tests/unit/test_skill_library.py tests/unit/test_skill_repository.py tests/unit/test_librarian_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d0895dbc832fbb8afd97cb495ac1