### PR TITLE
feat: suggest skills for plugin issues

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -14,6 +14,7 @@ from autogpt.event_bus import (
     EventMessage,
     MessageQueue,
 )
+from autogpt.skills.librarian import LibrarianAgent
 
 from .archaeologist_dependency import analyze_dependency
 
@@ -24,6 +25,7 @@ class Archaeologist:
     def __init__(self, message_queue: MessageQueue) -> None:
         self.message_queue = message_queue
         self.message_queue.subscribe(ISSUE_DETECTED, self._on_issue_detected)
+        self.librarian = LibrarianAgent()
 
     # ------------------------------------------------------------------
     def _on_issue_detected(self, event: EventMessage) -> None:
@@ -57,8 +59,6 @@ class Archaeologist:
                     metadata.get("file"), metadata.get("dependencies")
                 ),
             }
-
-            recommendations = self._recommendations(analysis)
 
             summary_parts = [
                 f"Diagnostics for plugin {plugin_id}" if plugin_id else "Diagnostics"
@@ -96,7 +96,6 @@ class Archaeologist:
                     metadata.get("file"), dep_info
                 )
             }
-            recommendations = self._recommendations(analysis)
             summary = (
                 f"Dependency update for plugin {plugin_id}"
                 if plugin_id
@@ -109,6 +108,38 @@ class Archaeologist:
             }
         else:
             return
+
+        query_parts: list[str] = []
+        if issue_type:
+            query_parts.append(issue_type.replace("_", " "))
+        if plugin_id:
+            query_parts.append(f"plugin {plugin_id}")
+        if error_log:
+            query_parts.append(str(error_log))
+        for k, v in metadata.items():
+            if isinstance(v, (str, int)):
+                query_parts.append(f"{k} {v}")
+        query = " ".join(query_parts)
+
+        skills = self.librarian.find_skill(query)
+        if skills:
+            skill = skills[0]
+            call_name = f"skill_{skill['skill_name']}_v{skill['version']}"
+            params = skill.get("parameters", {})
+            param_list = ", ".join(params.keys()) if params else "no parameters"
+            skill_rec = f"Invoke {call_name} with parameters: {param_list}."
+        else:
+            skill_rec = (
+                "No suitable skill found; consider developing a new skill."
+            )
+
+        base_rec = self._recommendations(analysis)
+        recs = []
+        if base_rec and base_rec != "No recommendations.":
+            recs.append(base_rec)
+        recs.append(skill_rec)
+        recommendations = " ".join(recs)
+        details["skill_search"] = skills
 
         self.message_queue.publish(
             DiagnosisComplete(

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 import types
 from pathlib import Path
+from unittest.mock import patch
 
 from autogpt.event_bus import (
     DIAGNOSIS_COMPLETE,
@@ -24,24 +25,25 @@ Archaeologist = arch_module.Archaeologist
 def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    Archaeologist(message_queue)
+    with patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]):
+        Archaeologist(message_queue)
 
-    received: list[DiagnosisComplete] = []
-    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+        received: list[DiagnosisComplete] = []
+        message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
-    payload = {
-        "plugin": "test_plugin",
-        "error_log": "traceback",
-        "commit": "HEAD",
-        "file": "autogpt/agents/agent.py",
-        "line": 10,
-        "extra": "meta",
-        "issue_type": "bug",
-    }
+        payload = {
+            "plugin": "test_plugin",
+            "error_log": "traceback",
+            "commit": "HEAD",
+            "file": "autogpt/agents/agent.py",
+            "line": 10,
+            "extra": "meta",
+            "issue_type": "bug",
+        }
 
-    message_queue.publish(
-        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
-    )
+        message_queue.publish(
+            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+        )
 
     assert len(received) == 1
     diag = received[0]
@@ -57,24 +59,25 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
 def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    Archaeologist(message_queue)
+    with patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]):
+        Archaeologist(message_queue)
 
-    received: list[DiagnosisComplete] = []
-    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+        received: list[DiagnosisComplete] = []
+        message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
-    payload = {
-        "plugin": "test_plugin",
-        "error_log": (
-            "Traceback (most recent call last):\n"
-            '  File "autogpt/agents/agent.py", line 42, in <module>\n'
-            "    raise Exception()\n"
-        ),
-        "issue_type": "bug",
-    }
+        payload = {
+            "plugin": "test_plugin",
+            "error_log": (
+                "Traceback (most recent call last):\n"
+                '  File "autogpt/agents/agent.py", line 42, in <module>\n'
+                "    raise Exception()\n"
+            ),
+            "issue_type": "bug",
+        }
 
-    message_queue.publish(
-        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
-    )
+        message_queue.publish(
+            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+        )
 
     assert "autogpt/agents/agent.py:42" in received[0].summary
 
@@ -82,20 +85,21 @@ def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
 def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    Archaeologist(message_queue)
+    with patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]):
+        Archaeologist(message_queue)
 
-    received: list[DiagnosisComplete] = []
-    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+        received: list[DiagnosisComplete] = []
+        message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
-    payload = {
-        "plugin": "test_plugin",
-        "error_log": "ERROR at autogpt/agents/agent.py:50 something went wrong",
-        "issue_type": "bug",
-    }
+        payload = {
+            "plugin": "test_plugin",
+            "error_log": "ERROR at autogpt/agents/agent.py:50 something went wrong",
+            "issue_type": "bug",
+        }
 
-    message_queue.publish(
-        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
-    )
+        message_queue.publish(
+            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+        )
 
     assert "autogpt/agents/agent.py:50" in received[0].summary
 
@@ -103,19 +107,20 @@ def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
 def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    Archaeologist(message_queue)
+    with patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]):
+        Archaeologist(message_queue)
 
-    received: list[DiagnosisComplete] = []
-    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+        received: list[DiagnosisComplete] = []
+        message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
 
-    payload = {
-        "plugin": "test_plugin",
-        "error_log": "unstructured log message",
-        "issue_type": "bug",
-    }
+        payload = {
+            "plugin": "test_plugin",
+            "error_log": "unstructured log message",
+            "issue_type": "bug",
+        }
 
-    message_queue.publish(
-        EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
-    )
+        message_queue.publish(
+            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+        )
 
     assert "autogpt/agents/agent.py" not in received[0].summary

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -60,6 +60,17 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
             "analyze_dependency",
             wraps=arch_module.analyze_dependency,
         ) as mock_analyze,
+        patch.object(
+            arch_module.LibrarianAgent,
+            "find_skill",
+            return_value=[
+                {
+                    "skill_name": "sample_skill",
+                    "version": "1",
+                    "parameters": {"path": "str"},
+                }
+            ],
+        ),
     ):
         payload = {
             "plugin": "test_plugin",
@@ -89,6 +100,7 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
         "Investigate compatibility issues in: sample_dep"
         in diag.actionable_recommendations
     )
+    assert "skill_sample_skill_v1" in diag.actionable_recommendations
     assert diag.details is not None
     blame = diag.details["blame"]
     assert blame["commit"] == "^123"
@@ -130,6 +142,7 @@ def test_archaeologist_agent_uses_dependency_new_version(tmp_path: Path) -> None
         patch.object(arch_module.subprocess, "run", side_effect=fake_run),
         patch.object(dep_module.metadata, "version", return_value="1.0"),
         patch.object(dep_module, "fetch_release_notes", side_effect=fake_fetch),
+        patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]),
     ):
         payload = {
             "plugin": "test_plugin",


### PR DESCRIPTION
## Summary
- import LibrarianAgent into archaeologist to suggest relevant skills for issues
- derive query from issue payload and include skill guidance in diagnosis
- update archaeologist tests to mock skill search

## Testing
- `pytest tests/unit/test_archaeologist.py tests/unit/test_archaeologist_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6891da37a234832fb843d2558a356fd3