### PR TITLE
Add description field to ISSUE_DETECTED payload

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -49,11 +49,12 @@ class Archaeologist:
 
         plugin_id = payload.get("plugin")
         error_log = payload.get("error_log")
+        description = payload.get("description")
         issue_type = payload.get("issue_type", "bug")
         metadata = {
             k: v
             for k, v in payload.items()
-            if k not in {"plugin", "error_log", "issue_type"}
+            if k not in {"plugin", "error_log", "issue_type", "description"}
         }
 
         if issue_type == "bug":
@@ -94,6 +95,8 @@ class Archaeologist:
                 "context": context,
                 "dependencies": analysis.get("dependencies"),
             }
+            if description:
+                details["description"] = description
 
         elif issue_type == "dependency_update":
             dep_info = metadata.get("dependencies")
@@ -118,20 +121,25 @@ class Archaeologist:
                 "error_log": error_log,
                 "dependencies": analysis.get("dependencies"),
             }
+            if description:
+                details["description"] = description
         else:
             return
 
-        query_parts: list[str] = []
-        if issue_type:
-            query_parts.append(issue_type.replace("_", " "))
-        if plugin_id:
-            query_parts.append(f"plugin {plugin_id}")
-        if error_log:
-            query_parts.append(str(error_log))
-        for k, v in metadata.items():
-            if isinstance(v, (str, int)):
-                query_parts.append(f"{k} {v}")
-        query = " ".join(query_parts)
+        if description:
+            query = description
+        else:
+            query_parts: list[str] = []
+            if issue_type:
+                query_parts.append(issue_type.replace("_", " "))
+            if plugin_id:
+                query_parts.append(f"plugin {plugin_id}")
+            if error_log:
+                query_parts.append(str(error_log))
+            for k, v in metadata.items():
+                if isinstance(v, (str, int)):
+                    query_parts.append(f"{k} {v}")
+            query = " ".join(query_parts)
 
         skills = self.librarian.find_skill(query)
         if skills:

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -45,6 +45,38 @@ DEPLOYMENT_FAILED = "DEPLOYMENT_FAILED"
 
 
 @dataclass(kw_only=True)
+class IssueDetected(EventMessage):
+    """Schema for :data:`ISSUE_DETECTED` events.
+
+    Expected payload fields:
+        issue_type: Categorisation such as ``"bug"`` or ``"dependency_update"``.
+        plugin: Identifier of the emitting component.
+        description: Human-readable summary of the issue.
+        error_log: Optional log snippet or message describing the problem.
+        metadata: Additional context like ``file``, ``line`` or ``commit``.
+    """
+
+    issue_type: str
+    plugin: str | None = None
+    description: str | None = None
+    error_log: str | None = None
+    metadata: dict[str, Any] | None = None
+    event_type: str = field(init=False, default=ISSUE_DETECTED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "issue_type": self.issue_type,
+            "plugin": self.plugin,
+            "description": self.description,
+            "error_log": self.error_log,
+        }
+        if self.metadata:
+            self.payload.update(self.metadata)
+        self.payload = {k: v for k, v in self.payload.items() if v is not None}
+
+
+@dataclass(kw_only=True)
 class DiagnosisComplete(EventMessage):
     """Schema for :data:`DIAGNOSIS_COMPLETE` events."""
 
@@ -201,6 +233,7 @@ class DeploymentFailed(EventMessage):
 
 __all__ = [
     "EventMessage",
+    "IssueDetected",
     "DiagnosisComplete",
     "CodeFixProposed",
     "HumanApprovalRequired",

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -38,11 +38,14 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
             "file": "autogpt/agents/agent.py",
             "line": 10,
             "extra": "meta",
+            "description": "traceback",
             "issue_type": "bug",
         }
 
         message_queue.publish(
-            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
         )
 
     assert len(received) == 1
@@ -72,11 +75,14 @@ def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:
                 '  File "autogpt/agents/agent.py", line 42, in <module>\n'
                 "    raise Exception()\n"
             ),
+            "description": "traceback",
             "issue_type": "bug",
         }
 
         message_queue.publish(
-            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
         )
 
     assert "autogpt/agents/agent.py:42" in received[0].summary
@@ -94,11 +100,14 @@ def test_archaeologist_parses_plugin_log(tmp_path: Path) -> None:
         payload = {
             "plugin": "test_plugin",
             "error_log": "ERROR at autogpt/agents/agent.py:50 something went wrong",
+            "description": "plugin log error",
             "issue_type": "bug",
         }
 
         message_queue.publish(
-            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
         )
 
     assert "autogpt/agents/agent.py:50" in received[0].summary
@@ -116,11 +125,14 @@ def test_archaeologist_parsing_fails_gracefully(tmp_path: Path) -> None:
         payload = {
             "plugin": "test_plugin",
             "error_log": "unstructured log message",
+            "description": "unstructured log message",
             "issue_type": "bug",
         }
 
         message_queue.publish(
-            EventMessage(event_type=ISSUE_DETECTED, payload=payload, source_agent="tester")
+            EventMessage(
+                event_type=ISSUE_DETECTED, payload=payload, source_agent="tester"
+            )
         )
 
     assert "autogpt/agents/agent.py" not in received[0].summary

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -79,6 +79,7 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
                 f'  File "{source_file}", line 1, in <module>'
             ),
             "commit": "abc123",
+            "description": "runtime error",
             "issue_type": "bug",
         }
         message_queue.publish(
@@ -151,6 +152,7 @@ def test_archaeologist_agent_uses_dependency_new_version(tmp_path: Path) -> None
                 f'  File "{source_file}", line 2, in <module>'
             ),
             "dependencies": {"sample_dep": {"new_version": "2.0"}},
+            "description": "dependency update",
             "issue_type": "dependency_update",
         }
         message_queue.publish(
@@ -182,6 +184,7 @@ def test_on_issue_detected_recommends_existing_skill() -> None:
             "plugin": "test_plugin",
             "issue_type": "bug",
             "error_log": "runtime error",
+            "description": "runtime error",
         }
         message_queue.publish(
             EventMessage(
@@ -207,6 +210,7 @@ def test_on_issue_detected_recommends_new_skill_when_none_found() -> None:
             "plugin": "test_plugin",
             "issue_type": "bug",
             "error_log": "runtime error",
+            "description": "runtime error",
         }
         message_queue.publish(
             EventMessage(

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from autogpt.dashboard import create_dashboard_app
 from autogpt.event_bus import (
@@ -18,7 +19,7 @@ def test_dashboard_tracks_events() -> None:
 
     event = EventMessage(
         event_type="ISSUE_DETECTED",
-        payload={"issue_id": "42", "issue_type": "bug"},
+        payload={"issue_id": "42", "issue_type": "bug", "description": "test bug"},
         source_agent="tester",
     )
     mq.publish(event)
@@ -51,7 +52,11 @@ def test_dashboard_streams_events_and_updates_state() -> None:
         events = [
             EventMessage(
                 event_type="ISSUE_DETECTED",
-                payload={"issue_id": "1", "issue_type": "bug"},
+                payload={
+                    "issue_id": "1",
+                    "issue_type": "bug",
+                    "description": "test bug",
+                },
                 source_agent="tester",
             ),
             EventMessage(
@@ -87,7 +92,7 @@ def test_dashboard_handles_missing_issue_id() -> None:
 
     event = EventMessage(
         event_type="ISSUE_DETECTED",
-        payload={"issue_type": "bug"},
+        payload={"issue_type": "bug", "description": "test bug"},
         source_agent="tester",
     )
     mq.publish(event)
@@ -115,7 +120,7 @@ def test_stream_removes_disconnected_clients() -> None:
         mq.publish(
             EventMessage(
                 event_type="ISSUE_DETECTED",
-                payload={"issue_type": "bug"},
+                payload={"issue_type": "bug", "description": "test bug"},
                 source_agent="tester",
             )
         )
@@ -124,13 +129,13 @@ def test_stream_removes_disconnected_clients() -> None:
         assert len(subscribers) == 0
 
 
-def test_dashboard_persists_events(tmp_path) -> None:
+def test_dashboard_persists_events(tmp_path: Path) -> None:
     db_file = tmp_path / "events.db"
     mq = MessageQueue()
     create_dashboard_app(mq, db_path=db_file)
     event = EventMessage(
         event_type="ISSUE_DETECTED",
-        payload={"issue_id": "7", "issue_type": "bug"},
+        payload={"issue_id": "7", "issue_type": "bug", "description": "test bug"},
         source_agent="tester",
     )
     mq.publish(event)


### PR DESCRIPTION
## Summary
- define IssueDetected schema with optional description field
- include description in Archaeologist query handling and details
- update unit tests to populate new description metadata

## Testing
- `pytest tests/unit/test_archaeologist_agent.py tests/unit/test_archaeologist.py tests/unit/test_dashboard.py`
- `pre-commit run --files autogpt/event_bus/message_types.py autogpt/agents/archaeologist.py tests/unit/test_archaeologist_agent.py tests/unit/test_archaeologist.py tests/unit/test_dashboard.py` *(fails: ERROR tests/unit/test_command_loop.py ...)*

------
https://chatgpt.com/codex/tasks/task_e_6891e3c04154832f8aca3ebe7d3e5db9