### PR TITLE
Add recommended skill to DiagnosisComplete details

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -148,8 +148,14 @@ class Archaeologist:
             params = skill.get("parameters", {})
             param_list = ", ".join(params.keys()) if params else "no parameters"
             skill_rec = f"Invoke {call_name} with parameters: {param_list}."
+            details["recommended_skill"] = {
+                "name": skill["skill_name"],
+                "version": skill["version"],
+                "parameters": params,
+            }
         else:
             skill_rec = "No suitable skill found; consider developing a new skill."
+            details["recommended_skill"] = None
 
         base_rec = self._recommendations(analysis)
         recs = []

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
 
 
 @dataclass
@@ -76,17 +76,37 @@ class IssueDetected(EventMessage):
         self.payload = {k: v for k, v in self.payload.items() if v is not None}
 
 
+class RecommendedSkill(TypedDict):
+    """Metadata describing a skill suggestion."""
+
+    name: str
+    version: str
+    parameters: dict[str, Any]
+
+
+class DiagnosisDetails(TypedDict, total=False):
+    """Extra information included with :class:`DiagnosisComplete`."""
+
+    recommended_skill: RecommendedSkill | None
+    # other optional fields such as ``skill_search`` or ``metadata`` may appear
+
+
 @dataclass(kw_only=True)
 class DiagnosisComplete(EventMessage):
     """Schema for :data:`DIAGNOSIS_COMPLETE` events."""
 
     summary: str
     actionable_recommendations: str
-    details: dict[str, Any] | None = None
+    details: DiagnosisDetails | None = None
     event_type: str = field(init=False, default=DIAGNOSIS_COMPLETE)
     payload: dict[str, Any] | str | None = field(init=False)
 
     def __post_init__(self) -> None:
+        if self.details is None:
+            self.details = {"recommended_skill": None}
+        else:
+            self.details.setdefault("recommended_skill", None)
+
         self.payload = {
             "summary": self.summary,
             "actionable_recommendations": self.actionable_recommendations,

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -82,10 +82,11 @@ Expected `ISSUE_DETECTED` payload fields:
 ### Librarian integration and event payload
 
 `LibrarianAgent.find_skill` enables the archaeologist to reuse prior work. The
-agent includes the raw search results in the `skill_search` field of the
-`DIAGNOSIS_COMPLETE` event's `details`. When a match is found the event's
-`actionable_recommendations` directs consumers to invoke the suggested skill;
-otherwise it signals that a new skill may be needed.
+agent includes the raw search results in the `skill_search` field and the top
+match in `recommended_skill` within the `DIAGNOSIS_COMPLETE` event's
+`details`. When a match is found the event's `actionable_recommendations`
+directs consumers to invoke the suggested skill; otherwise it signals that a
+new skill may be needed.
 
 ### Event bus and tool requirements
 
@@ -106,9 +107,9 @@ archaeologist.librarian = librarian
 
 
 def handle_diagnostics(event: DiagnosisComplete) -> None:
-    skills = event.details.get("skill_search", [])
-    if skills:
-        print(f"Matched skill: {skills[0]['skill_name']}")
+    rec = event.details["recommended_skill"]
+    if rec:
+        print(f"Matched skill: {rec['name']}")
     else:
         print("No matching skill found")
 
@@ -120,7 +121,14 @@ handle_diagnostics(
     DiagnosisComplete(
         summary="",
         actionable_recommendations="",
-        details={"skill_search": [{"skill_name": "skill_example", "version": 1}]},
+        details={
+            "skill_search": [{"skill_name": "skill_example", "version": "1"}],
+            "recommended_skill": {
+                "name": "skill_example",
+                "version": "1",
+                "parameters": {},
+            },
+        },
         source_agent="archaeologist",
     )
 )  # -> Matched skill: skill_example
@@ -128,7 +136,7 @@ handle_diagnostics(
     DiagnosisComplete(
         summary="",
         actionable_recommendations="",
-        details={"skill_search": []},
+        details={"skill_search": [], "recommended_skill": None},
         source_agent="archaeologist",
     )
 )  # -> No matching skill found
@@ -179,10 +187,10 @@ Diagnostics for plugin example-plugin at example.py:10
 Invoke skill_example_v1 with parameters: no parameters.
 ```
 
-The event's `details` include a `skill_search` array with the raw result so
-other components can decide whether to call the skill directly or craft a new
-one. Other components subscribed to `DIAGNOSIS_COMPLETE` can display the
-message to users or log it for further analysis.
+The event's `details` include a `skill_search` array with the raw result and a
+`recommended_skill` entry containing the suggested skill (or `None`). Other
+components subscribed to `DIAGNOSIS_COMPLETE` can display the message to users
+or log it for further analysis.
 
 ## TDDDeveloperAgent
 

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -57,6 +57,7 @@ def test_archaeologist_handles_issue(tmp_path: Path) -> None:
     assert diag.details["blame"]["author"]
     assert any(c["line"] == 10 for c in diag.details["context"])
     assert isinstance(diag.details["dependencies"], list)
+    assert diag.details["recommended_skill"] is None
 
 
 def test_archaeologist_parses_python_traceback(tmp_path: Path) -> None:

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -109,6 +109,11 @@ def test_archaeologist_agent_diagnosis_complete(tmp_path: Path) -> None:
     assert blame["text"].startswith("^123")
     assert diag.details["context"][0]["content"].strip() == "import sample_dep"
     assert diag.details["dependencies"][0]["dependency"] == "sample_dep"
+    assert diag.details["recommended_skill"] == {
+        "name": "sample_skill",
+        "version": "1",
+        "parameters": {"path": "str"},
+    }
 
 
 def test_archaeologist_agent_uses_dependency_new_version(tmp_path: Path) -> None:
@@ -167,6 +172,7 @@ def test_archaeologist_agent_uses_dependency_new_version(tmp_path: Path) -> None
     assert dep_analysis["new_version"] == "2.0"
     assert any("sample_dep 2.0" in f for f in dep_analysis["findings"])
     assert all(cmd[0] != "git" for cmd in commands)
+    assert received[0].details["recommended_skill"] is None
 
 
 def test_on_issue_detected_recommends_existing_skill() -> None:
@@ -195,6 +201,11 @@ def test_on_issue_detected_recommends_existing_skill() -> None:
     assert len(received) == 1
     diag = received[0]
     assert "skill_mock_v1" in diag.actionable_recommendations
+    assert diag.details["recommended_skill"] == {
+        "name": "mock",
+        "version": "1",
+        "parameters": {},
+    }
 
 
 def test_on_issue_detected_recommends_new_skill_when_none_found() -> None:
@@ -224,3 +235,4 @@ def test_on_issue_detected_recommends_new_skill_when_none_found() -> None:
         diag.actionable_recommendations
         == "No suitable skill found; consider developing a new skill."
     )
+    assert diag.details["recommended_skill"] is None

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -52,11 +52,13 @@ def test_message_queue_diagnosis_complete(message_queue: MessageQueue) -> None:
     assert len(received) == 1
     assert isinstance(received[0], DiagnosisComplete)
     assert received[0].summary == "Diagnostics complete"
+    assert received[0].details["recommended_skill"] is None
 
     events = list(message_queue.get_events())
     assert len(events) == 1
     assert isinstance(events[0], DiagnosisComplete)
     assert events[0].summary == "Diagnostics complete"
+    assert events[0].details["recommended_skill"] is None
 
 
 def test_message_queue_publish_from_multiple_sources(


### PR DESCRIPTION
## Summary
- include `recommended_skill` metadata in `DiagnosisComplete.details`
- document new `recommended_skill` field for diagnosis events
- test skill recommendation appears when available

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/agents/archaeologist.py autogpt/event_bus/message_types.py docs/architecture/agents.md tests/unit/test_archaeologist.py tests/unit/test_archaeologist_agent.py tests/unit/test_event_bus.py`
- `pytest tests/unit/test_archaeologist.py tests/unit/test_archaeologist_agent.py tests/unit/test_event_bus.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e8ef91a0832fbf178a6ec636bd3a