### PR TITLE
Add action for missing skill match

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -154,7 +154,10 @@ class Archaeologist:
                 "parameters": params,
             }
         else:
-            skill_rec = "No suitable skill found; consider developing a new skill."
+            skill_rec = (
+                "No suitable skill found; consider developing a new skill. "
+                "Start new skill development process."
+            )
             details["recommended_skill"] = None
 
         base_rec = self._recommendations(analysis)

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -75,7 +75,8 @@ Expected `ISSUE_DETECTED` payload fields:
 2. **Query librarian** – Build a search string from the issue details and call
    `LibrarianAgent.find_skill` to look for existing remediation skills.
 3. **Branch on results** – If a relevant skill is found, recommend invoking it;
-   otherwise advise creating a new skill or applying manual fixes.
+    otherwise advise creating a new skill, start the skill development process,
+    or apply manual fixes.
 4. **Publish `DIAGNOSIS_COMPLETE`** – Emit diagnostics summarising the issue
    and the skill search outcome for downstream agents.
 
@@ -86,7 +87,7 @@ agent includes the raw search results in the `skill_search` field and the top
 match in `recommended_skill` within the `DIAGNOSIS_COMPLETE` event's
 `details`. When a match is found the event's `actionable_recommendations`
 directs consumers to invoke the suggested skill; otherwise it signals that a
-new skill may be needed.
+new skill may be needed and to start the skill development process.
 
 ### Event bus and tool requirements
 

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -233,6 +233,6 @@ def test_on_issue_detected_recommends_new_skill_when_none_found() -> None:
     diag = received[0]
     assert (
         diag.actionable_recommendations
-        == "No suitable skill found; consider developing a new skill."
+        == "No suitable skill found; consider developing a new skill. Start new skill development process."
     )
     assert diag.details["recommended_skill"] is None


### PR DESCRIPTION
## Summary
- append a new guidance string when the archaeologist agent finds no skill match
- document the new step in the agent workflow
- adjust unit test to expect the updated recommendation text

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/agents/archaeologist.py docs/architecture/agents.md tests/unit/test_archaeologist_agent.py`
- `pytest tests/unit/test_archaeologist_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ecf505cc832fac48995f93658155