### PR TITLE
Handle Librarian errors in archaeologist

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -17,6 +17,7 @@ from autogpt.event_bus import (
 )
 from autogpt.event_bus.message_types import DiagnosisDetails
 from autogpt.skills.librarian import LibrarianAgent
+from autogpt.logs import logger
 
 from .archaeologist_dependency import analyze_dependency
 
@@ -145,7 +146,11 @@ class Archaeologist:
                     query_parts.append(f"{k} {v}")
             query = " ".join(query_parts)
 
-        skills = self.librarian.find_skill(query)
+        try:
+            skills = self.librarian.find_skill(query)
+        except Exception as err:  # noqa: BLE001
+            logger.error(f"Error searching for skill: {err}")
+            skills = []
         if skills:
             skill = skills[0]
             call_name = f"skill_{skill['skill_name']}_v{skill['version']}"

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -248,3 +248,37 @@ def test_on_issue_detected_recommends_new_skill_when_none_found(
     )
     assert diag.details is not None
     assert diag.details["recommended_skill"] is None
+
+
+@pytest.mark.parametrize("event_type", [ISSUE_DETECTED, TICKET_RECEIVED])
+def test_on_issue_detected_handles_skill_exception(event_type: str) -> None:
+    message_queue = MessageQueue()
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    with (
+        patch.object(arch_module, "LibrarianAgent") as MockLib,
+        patch.object(arch_module.logger, "error") as mock_error,
+    ):
+        MockLib.return_value.find_skill.side_effect = RuntimeError("boom")
+        Archaeologist(message_queue)
+
+        payload = {
+            "plugin": "test_plugin",
+            "issue_type": "bug",
+            "error_log": "runtime error",
+            "description": "runtime error",
+        }
+        message_queue.publish(
+            EventMessage(event_type=event_type, payload=payload, source_agent="tester")
+        )
+
+    assert len(received) == 1
+    diag = received[0]
+    assert (
+        diag.actionable_recommendations
+        == "No suitable skill found; consider developing a new skill. Start new skill development process."
+    )
+    assert diag.details is not None
+    assert diag.details["recommended_skill"] is None
+    assert mock_error.called


### PR DESCRIPTION
## Summary
- guard `LibrarianAgent.find_skill` with try/except so archaeologist can continue when lookup fails
- log lookup failures and treat as no skills found
- add regression test covering exception during skill search

## Testing
- `pytest tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_existing_skill tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_new_skill_when_none_found tests/unit/test_archaeologist_agent.py::test_on_issue_detected_handles_skill_exception -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f23dbcc4832f8d90e8506c9e8893