### PR TITLE
Log skill search query and top skill metadata

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -16,6 +16,7 @@ from autogpt.event_bus import (
     MessageQueue,
 )
 from autogpt.event_bus.message_types import DiagnosisDetails
+from autogpt.logs import logger
 from autogpt.skills.librarian import LibrarianAgent
 
 from .archaeologist_dependency import analyze_dependency
@@ -145,8 +146,11 @@ class Archaeologist:
                     query_parts.append(f"{k} {v}")
             query = " ".join(query_parts)
 
+        logger.debug(f"Skill search query: {query}")
+
         skills = self.librarian.find_skill(query)
         if skills:
+            logger.debug(f"Top skill match: {skills[0]}")
             skill = skills[0]
             call_name = f"skill_{skill['skill_name']}_v{skill['version']}"
             params = skill.get("parameters", {})
@@ -158,6 +162,7 @@ class Archaeologist:
                 "parameters": params,
             }
         else:
+            logger.debug("No skill match found")
             skill_rec = (
                 "No suitable skill found; consider developing a new skill. "
                 "Start new skill development process."


### PR DESCRIPTION
## Summary
- log skill search query generated by archaeologist agent
- log top returned skill metadata at debug level

## Testing
- `SKIP=autoflake pre-commit run --files autogpt/agents/archaeologist.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest tests/unit/test_archaeologist_agent.py::test_archaeologist_agent_diagnosis_complete -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6891f23e07a0832fbe3436849953d31b