### PR TITLE
docs: describe librarian diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ queue.subscribe("example", handler)
 queue.publish(EventMessage(event_type="example", payload={"foo": "bar"}, source_agent="demo"))
 ```
 
+## Librarian 诊断
+
+`ArchaeologistAgent` 现可借助 `LibrarianAgent` 搜索技能库，为插件或运行时问题提供修复建议，形成 Librarian 驱动的诊断流程。更多架构细节请参阅 [docs/architecture/agents.md](docs/architecture/agents.md)。
+
 ## 编排器与仪表盘
 
 仓库包含一个简易的编排器，用于启动并监督这些事件驱动的代理：


### PR DESCRIPTION
## Summary
- document librarian-driven diagnostics in README

## Testing
- `pre-commit run --files README.md` *(fails: tests/unit/test_command_loop.py, test_criticism_repetition.py, test_dashboard.py, test_orchestrator.py, test_retry_provider_openai.py, test_simple_agent.py, test_utils.py, test_web_search.py, test_write_file_ability.py: 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891f26cebd4832f9706be7cb4efab77