### PR TITLE
Include skill parameters in diagnosis events

### DIFF
--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -120,6 +120,10 @@ class DiagnosisComplete(EventMessage):
         else:
             self.details.setdefault("recommended_skill", None)
 
+        rec = self.details.get("recommended_skill")
+        if isinstance(rec, dict):
+            rec.setdefault("parameters", {})
+
         self.payload = {
             "summary": self.summary,
             "actionable_recommendations": self.actionable_recommendations,

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -109,7 +109,10 @@ archaeologist.librarian = librarian
 def handle_diagnostics(event: DiagnosisComplete) -> None:
     rec = event.details["recommended_skill"]
     if rec:
-        print(f"Matched skill: {rec['name']}")
+        call_name = f"skill_{rec['name']}_v{rec['version']}"
+        print(
+            f"Matched skill: {call_name} with parameters {rec['parameters']}"
+        )
     else:
         print("No matching skill found")
 
@@ -131,7 +134,7 @@ handle_diagnostics(
         },
         source_agent="archaeologist",
     )
-)  # -> Matched skill: skill_example
+)  # -> Matched skill: skill_skill_example_v1 with parameters {}
 handle_diagnostics(
     DiagnosisComplete(
         summary="",
@@ -188,7 +191,8 @@ Invoke skill_example_v1 with parameters: no parameters.
 ```
 
 The event's `details` include a `skill_search` array with the raw result and a
-`recommended_skill` entry containing the suggested skill (or `None`). Other
+`recommended_skill` entry containing the suggested skill's name, version, and
+parameter schema (or `None`). Other
 components subscribed to `DIAGNOSIS_COMPLETE` can display the message to users
 or log it for further analysis.
 

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -61,6 +61,34 @@ def test_message_queue_diagnosis_complete(message_queue: MessageQueue) -> None:
     assert events[0].details["recommended_skill"] is None
 
 
+def test_message_queue_diagnosis_complete_recommended_skill(
+    message_queue: MessageQueue,
+) -> None:
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    event = DiagnosisComplete(
+        summary="Diagnostics complete",
+        actionable_recommendations="Invoke skill",
+        details={
+            "recommended_skill": {
+                "name": "skill_example",
+                "version": "1",
+                "parameters": {"path": "str"},
+            }
+        },
+        source_agent="archaeologist",
+    )
+    message_queue.publish(event)
+
+    rec = received[0].details["recommended_skill"]
+    assert rec == {
+        "name": "skill_example",
+        "version": "1",
+        "parameters": {"path": "str"},
+    }
+
+
 def test_message_queue_publish_from_multiple_sources(
     message_queue: MessageQueue,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure `DiagnosisComplete` always carries parameter schema for any recommended skill
- document how to access recommended skill metadata and parameters
- test downstream retrieval of recommended skill information

## Testing
- `SKIP=autoflake pre-commit run --files autogpt/event_bus/message_types.py docs/architecture/agents.md tests/unit/test_event_bus.py` *(fails: ModuleNotFoundError: No module named 'colorama')*
- `pytest tests/unit/test_event_bus.py tests/unit/test_archaeologist_agent.py tests/integration/test_archaeologist_event_flow.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6891f52d5ea4832fa622bf1969328dbf