### PR TITLE
Add example skill and document usage

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -108,6 +108,10 @@ Select the backend with `SKILL_DB_PROVIDER` in `.env`:
 - `chroma` — install with `pip install chromadb` to persist data in `skill_library/chroma`.
 - `faiss` — install with `pip install faiss-cpu` to persist data in `skill_library/faiss`.
 
+An example skill `hello_world_1.0` lives in `skill_library/`.
+Run its unit test with `pytest skill_library/hello_world_1.0/test_main.py`
+and use it as a template for building your own skills.
+
 ## Running the app
 
 ```bash

--- a/docs/architecture/skill_library.md
+++ b/docs/architecture/skill_library.md
@@ -10,6 +10,19 @@ kept in a dedicated folder named `<skill>_<version>` containing:
 - `requirements.txt` – optional dependencies
 - `skill.json` – metadata describing the skill
 
+## Example
+
+A minimal sample skill `hello_world_1.0` is available in the repository's
+`skill_library/` directory. Its `run` function simply returns the string
+`"Hello, world!"` and `skill.json` shows the required metadata layout. Run its
+unit test with:
+
+```bash
+pytest skill_library/hello_world_1.0/test_main.py
+```
+
+Use this folder as a template when creating your own skills.
+
 ## Metadata Schema
 
 `skill.json` provides structured information used when loading and searching

--- a/skill_library/hello_world_1.0/main.py
+++ b/skill_library/hello_world_1.0/main.py
@@ -1,0 +1,6 @@
+"""Minimal example skill that returns a friendly greeting."""
+
+
+def run() -> str:
+    """Return a friendly greeting."""
+    return "Hello, world!"

--- a/skill_library/hello_world_1.0/skill.json
+++ b/skill_library/hello_world_1.0/skill.json
@@ -1,0 +1,7 @@
+{
+  "skill_name": "hello_world",
+  "version": "1.0",
+  "description": "Return a friendly greeting",
+  "tags": ["example", "greeting"],
+  "parameters": {}
+}

--- a/skill_library/hello_world_1.0/test_main.py
+++ b/skill_library/hello_world_1.0/test_main.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_main() -> ModuleType:
+    spec: ModuleSpec | None = importlib.util.spec_from_file_location(
+        "main", Path(__file__).parent / "main.py"
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_returns_hello_world() -> None:
+    main = _load_main()
+    assert main.run() == "Hello, world!"

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -5,16 +5,19 @@ from pathlib import Path
 import pytest
 
 from autogpt.config import Config
+from autogpt.skills import library as library_module
 from autogpt.skills.librarian import LibrarianAgent
 
 
 def _setup_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LibrarianAgent:
-    agent = LibrarianAgent(Config())
-    agent.skill_library.storage_path = tmp_path
     monkeypatch.setattr(
         "autogpt.skills.library.get_embedding", lambda _text, _config: [0.1, 0.2, 0.3]
     )
-    return agent
+    monkeypatch.setattr(
+        "autogpt.skills.librarian.SkillLibrary",
+        lambda config: library_module.SkillLibrary(config, storage_path=tmp_path),
+    )
+    return LibrarianAgent(Config())
 
 
 def _metadata() -> dict:


### PR DESCRIPTION
## Summary
- add a minimal `hello_world` example skill with metadata and unit test
- document how to use the sample skill in the architecture docs and README
- adjust librarian agent tests to patch the skill library before instantiation

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files skill_library/hello_world_1.0/main.py skill_library/hello_world_1.0/test_main.py skill_library/hello_world_1.0/skill.json docs/architecture/skill_library.md README.en.md tests/unit/test_librarian_agent.py`
- `pytest skill_library/hello_world_1.0/test_main.py tests/unit/test_skill_library.py tests/unit/test_librarian_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6892033e1dec832fa54930c143883e1a