### PR TITLE
Cache repeated librarian queries

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 """Agent wrapper around :class:`SkillLibrary` for managing skills."""
 
-from dataclasses import asdict
 import shutil
+from dataclasses import asdict
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Tuple
 
 from autogpt.config import Config
 from autogpt.logs import logger
@@ -18,15 +18,29 @@ class LibrarianAgent:
 
     def __init__(self, config: Config | None = None) -> None:
         self.skill_library = SkillLibrary(config or Config())
+        # Cache search results to avoid redundant library queries for repeated
+        # requests. This keeps ``find_skill`` simple and synchronous while
+        # still improving performance for common lookups.
+        self._search_cache: Dict[Tuple[str, int], List[dict]] = {}
 
     # ------------------------------------------------------------------
     def find_skill(self, query: str, top_k: int = 3) -> List[dict]:
-        """Search for skills matching ``query`` and return their metadata."""
+        """Search for skills matching ``query`` and return their metadata.
+
+        Results are cached by ``query``/``top_k`` combination so repeated
+        invocations avoid hitting the underlying :class:`SkillLibrary`.
+        """
+
+        cache_key = (query, top_k)
+        if cache_key in self._search_cache:
+            return self._search_cache[cache_key]
 
         skills = self.skill_library.search(query, top_k=top_k)
         top_metadata = asdict(skills[0].metadata) if skills else None
         logger.debug(f"Skill search query: {query}, top result: {top_metadata}")
-        return [asdict(skill.metadata) for skill in skills]
+        results = [asdict(skill.metadata) for skill in skills]
+        self._search_cache[cache_key] = results
+        return results
 
     # ------------------------------------------------------------------
     def add_skill(self, skill_metadata: dict, skill_code_path: str) -> bool:
@@ -51,7 +65,10 @@ class LibrarianAgent:
             return False
 
         # Copy the code into the skill library directory
-        dest_dir = self.skill_library.storage_path / f"{metadata.skill_name}_{metadata.version}"
+        dest_dir = (
+            self.skill_library.storage_path
+            / f"{metadata.skill_name}_{metadata.version}"
+        )
         try:
             dest_dir.mkdir(parents=True, exist_ok=True)
             dest_file = dest_dir / "main.py"

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -88,6 +88,10 @@ match in `recommended_skill` within the `DIAGNOSIS_COMPLETE` event's
 directs consumers to invoke the suggested skill; otherwise it signals that new
 skill development is recommended.
 
+Repeated calls to `find_skill` are cached by the librarian so common queries do
+not repeatedly hit the underlying skill library. This keeps the interface
+simple and synchronous while still avoiding unnecessary work.
+
 ### Event bus and tool requirements
 
 ```python

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -70,3 +70,31 @@ def test_add_skill_missing_code_path_returns_false(
     missing_path = tmp_path / "missing.py"
 
     assert agent.add_skill(metadata, str(missing_path)) is False
+
+
+def test_find_skill_caches_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+    code_file = tmp_path / "skill.py"
+    code_file.write_text("def run():\n    return 'hello'\n")
+
+    metadata = _metadata()
+    assert agent.add_skill(metadata, str(code_file)) is True
+
+    call_count = 0
+    original_search = library_module.SkillLibrary.search
+
+    def counting_search(
+        self: library_module.SkillLibrary, query: str, top_k: int = 3
+    ) -> list:
+        nonlocal call_count
+        call_count += 1
+        return original_search(self, query, top_k=top_k)
+
+    monkeypatch.setattr(library_module.SkillLibrary, "search", counting_search)
+
+    agent.find_skill("Test skill")
+    agent.find_skill("Test skill")
+
+    assert call_count == 1


### PR DESCRIPTION
## Summary
- cache LibrarianAgent skill searches to avoid duplicate lookups
- document LibrarianAgent caching in architecture docs
- add unit test verifying cache hits

## Testing
- `python -m pre_commit run --files autogpt/skills/librarian.py tests/unit/test_librarian_agent.py docs/architecture/agents.md` *(fails: No module named 'jinja2')*
- `pytest tests/unit/test_librarian_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68920921f7c4832fa12678f155996206