### PR TITLE
Validate skill metadata in find_skill

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -38,7 +38,34 @@ class LibrarianAgent:
         skills = self.skill_library.search(query, top_k=top_k)
         top_metadata = asdict(skills[0].metadata) if skills else None
         logger.debug(f"Skill search query: {query}, top result: {top_metadata}")
-        results = [asdict(skill.metadata) for skill in skills]
+
+        required_fields = ("skill_name", "version", "parameters")
+        results: List[dict] = []
+        for skill in skills:
+            metadata = getattr(skill, "metadata", None)
+            if metadata is None:
+                logger.warn("Skipping skill with missing metadata: %s", skill)
+                continue
+
+            if isinstance(metadata, dict):
+                meta_dict = metadata
+            else:
+                try:
+                    meta_dict = asdict(metadata)
+                except Exception:
+                    logger.warn("Skipping skill with invalid metadata: %s", metadata)
+                    continue
+
+            if not all(meta_dict.get(field) for field in required_fields):
+                logger.warn(
+                    "Skipping skill with missing required fields %s: %s",
+                    required_fields,
+                    meta_dict,
+                )
+                continue
+
+            results.append(meta_dict)
+
         self._search_cache[cache_key] = results
         return results
 

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -98,3 +100,45 @@ def test_find_skill_caches_results(
     agent.find_skill("Test skill")
 
     assert call_count == 1
+
+
+def test_find_skill_skips_missing_required_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+
+    valid_meta = library_module.SkillMetadata(**_metadata())
+    invalid_meta = {"skill_name": "bad", "version": "1.0"}
+
+    skills = [
+        SimpleNamespace(metadata=valid_meta),
+        SimpleNamespace(metadata=invalid_meta),
+    ]
+
+    monkeypatch.setattr(
+        library_module.SkillLibrary, "search", lambda self, q, top_k=3: skills
+    )
+
+    results = agent.find_skill("Test skill")
+
+    assert results == [asdict(valid_meta)]
+
+
+def test_find_skill_skips_non_mapping_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+
+    valid_meta = library_module.SkillMetadata(**_metadata())
+    skills = [
+        SimpleNamespace(metadata=valid_meta),
+        SimpleNamespace(metadata=object()),
+    ]
+
+    monkeypatch.setattr(
+        library_module.SkillLibrary, "search", lambda self, q, top_k=3: skills
+    )
+
+    results = agent.find_skill("Test skill")
+
+    assert results == [asdict(valid_meta)]


### PR DESCRIPTION
## Summary
- validate required fields when processing skill search results
- skip results missing required metadata
- test librarian agent behavior with invalid skill metadata

## Testing
- `pytest tests/unit/test_librarian_agent.py`
- `pre-commit run --files autogpt/skills/librarian.py tests/unit/test_librarian_agent.py` *(fails: ModuleNotFoundError: No module named 'jinja2', 'flask', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68920f4830a0832fac5881b9f43d1e20