### PR TITLE
Add telemetry hooks for skill search

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Tuple
 
 from autogpt.config import Config
 from autogpt.logs import logger
+from autogpt.telemetry import telemetry
 
 from .library import SkillLibrary, SkillMetadata
 
@@ -33,7 +34,11 @@ class LibrarianAgent:
 
         cache_key = (query, top_k)
         if cache_key in self._search_cache:
-            return self._search_cache[cache_key]
+            results = self._search_cache[cache_key]
+            telemetry.increment(
+                "find_skill.success" if results else "find_skill.failure"
+            )
+            return results
 
         skills = self.skill_library.search(query, top_k=top_k)
         top_metadata = asdict(skills[0].metadata) if skills else None
@@ -67,6 +72,7 @@ class LibrarianAgent:
             results.append(meta_dict)
 
         self._search_cache[cache_key] = results
+        telemetry.increment("find_skill.success" if results else "find_skill.failure")
         return results
 
     # ------------------------------------------------------------------

--- a/autogpt/telemetry/__init__.py
+++ b/autogpt/telemetry/__init__.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Lightweight telemetry utilities for AutoGPT.
+
+This module provides minimal in-memory counting of events and exposes hooks
+for future integration with external monitoring or metrics backends. The
+current implementation stores counters locally but allows registration of
+callback hooks that can pipe metrics to third-party systems.
+"""
+
+from collections import Counter
+from typing import Callable, Dict, Iterable
+
+
+class Telemetry:
+    """Simple telemetry collector.
+
+    Counts occurrences of named events and notifies optional hooks whenever a
+    counter is incremented. Hooks may be used to forward metrics to external
+    monitoring services.
+    """
+
+    def __init__(self) -> None:
+        self._counters: Counter[str] = Counter()
+        self._hooks: list[Callable[[str, int], None]] = []
+
+    # ------------------------------------------------------------------
+    def increment(self, name: str, value: int = 1) -> None:
+        """Increment ``name`` by ``value`` and notify hooks."""
+
+        self._counters[name] += value
+        for hook in list(self._hooks):
+            try:
+                hook(name, self._counters[name])
+            except Exception:
+                # Hooks are best-effort; errors are ignored to avoid impacting
+                # core functionality.
+                continue
+
+    # ------------------------------------------------------------------
+    def get_counts(self) -> Dict[str, int]:
+        """Return a snapshot of all counters."""
+
+        return dict(self._counters)
+
+    # ------------------------------------------------------------------
+    def reset(self, names: Iterable[str] | None = None) -> None:
+        """Reset counters for ``names`` or all counters if ``names`` is None."""
+
+        if names is None:
+            self._counters.clear()
+        else:
+            for name in names:
+                self._counters.pop(name, None)
+
+    # ------------------------------------------------------------------
+    def register_hook(self, hook: Callable[[str, int], None]) -> None:
+        """Register a hook to be called when counters are incremented."""
+
+        self._hooks.append(hook)
+
+
+telemetry = Telemetry()

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -9,6 +9,7 @@ import pytest
 from autogpt.config import Config
 from autogpt.skills import library as library_module
 from autogpt.skills.librarian import LibrarianAgent
+from autogpt.telemetry import telemetry
 
 
 def _setup_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LibrarianAgent:
@@ -142,3 +143,29 @@ def test_find_skill_skips_non_mapping_metadata(
     results = agent.find_skill("Test skill")
 
     assert results == [asdict(valid_meta)]
+
+
+def test_find_skill_records_telemetry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+    code_file = tmp_path / "skill.py"
+    code_file.write_text("def run():\n    return 'hello'\n")
+
+    metadata = _metadata()
+    assert agent.add_skill(metadata, str(code_file)) is True
+
+    telemetry.reset()
+
+    # Successful search
+    agent.find_skill("Test skill")
+
+    # Failed search: force library search to return no results
+    monkeypatch.setattr(
+        library_module.SkillLibrary, "search", lambda self, q, top_k=3: []
+    )
+    agent.find_skill("Missing skill")
+
+    counts = telemetry.get_counts()
+    assert counts.get("find_skill.success", 0) == 1
+    assert counts.get("find_skill.failure", 0) == 1


### PR DESCRIPTION
## Summary
- add lightweight telemetry module with counters and hook registration
- instrument LibrarianAgent.find_skill to record success/failure stats
- cover telemetry counts with new unit test

## Testing
- `pytest tests/unit/test_librarian_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689213dc231c832fb010be20ab6016b6