### PR TITLE
Select top scoring skill from librarian results

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -150,14 +150,18 @@ class Archaeologist:
         }
         query = self._generate_query(query_payload)
 
-        skills = []
+        skills: list[dict[str, Any]] = []
+        top_k = 3
         if self.librarian:
             try:
-                skills = self.librarian.find_skill(query)
+                skills = self.librarian.find_skill(query, top_k=top_k)
             except Exception as err:  # noqa: BLE001
                 logger.error(f"Error searching for skill: {err}")
         if skills:
-            skill = skills[0]
+            if any("score" in s for s in skills):
+                skill = max(skills, key=lambda s: s.get("score", float("-inf")))
+            else:
+                skill = skills[0]
             call_name = f"skill_{skill['skill_name']}_v{skill['version']}"
             params = skill.get("parameters", {})
             param_list = ", ".join(params.keys()) if params else "no parameters"
@@ -179,7 +183,7 @@ class Archaeologist:
             recs.append(base_rec)
         recs.append(skill_rec)
         recommendations = " ".join(recs)
-        details["skill_search"] = skills
+        details["skill_search"] = skills[:top_k]
 
         event = DiagnosisComplete(
             summary=summary,

--- a/tests/integration/test_archaeologist_event_flow.py
+++ b/tests/integration/test_archaeologist_event_flow.py
@@ -22,10 +22,17 @@ def test_archaeologist_recommends_skill_without_git_ops(monkeypatch, use_librari
         def find_skill(self, query: str, top_k: int = 3):
             return [
                 {
-                    "skill_name": "sample_skill",
+                    "skill_name": "sample_low",
                     "version": "1",
                     "parameters": {"path": "str"},
-                }
+                    "score": 0.1,
+                },
+                {
+                    "skill_name": "sample_high",
+                    "version": "2",
+                    "parameters": {"path": "str"},
+                    "score": 0.9,
+                },
             ]
 
     Archaeologist(
@@ -70,11 +77,25 @@ def test_archaeologist_recommends_skill_without_git_ops(monkeypatch, use_librari
     diag = received[0]
     if use_librarian:
         assert diag.details["recommended_skill"] == {
-            "name": "sample_skill",
-            "version": "1",
+            "name": "sample_high",
+            "version": "2",
             "parameters": {"path": "str"},
         }
-        assert "skill_sample_skill_v1" in diag.actionable_recommendations
+        assert diag.details["skill_search"] == [
+            {
+                "skill_name": "sample_low",
+                "version": "1",
+                "parameters": {"path": "str"},
+                "score": 0.1,
+            },
+            {
+                "skill_name": "sample_high",
+                "version": "2",
+                "parameters": {"path": "str"},
+                "score": 0.9,
+            },
+        ]
+        assert "skill_sample_high_v2" in diag.actionable_recommendations
     else:
         assert diag.details["recommended_skill"] is None
-        assert "skill_sample_skill_v1" not in diag.actionable_recommendations
+        assert "skill_sample_high_v2" not in diag.actionable_recommendations

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -196,7 +196,8 @@ def test_on_issue_detected_recommends_existing_skill(event_type: str) -> None:
 
     with patch.object(arch_module, "LibrarianAgent") as MockLib:
         MockLib.return_value.find_skill.return_value = [
-            {"skill_name": "mock", "version": "1", "parameters": {}}
+            {"skill_name": "mock_low", "version": "1", "parameters": {}, "score": 0.2},
+            {"skill_name": "mock_high", "version": "2", "parameters": {}, "score": 0.9},
         ]
         Archaeologist(message_queue)
 
@@ -212,14 +213,18 @@ def test_on_issue_detected_recommends_existing_skill(event_type: str) -> None:
 
     assert len(received) == 1
     diag = received[0]
-    assert "skill_mock_v1" in diag.actionable_recommendations
+    assert "skill_mock_high_v2" in diag.actionable_recommendations
     assert diag.details is not None
     details = cast(dict[str, Any], diag.details)
     assert details["recommended_skill"] == {
-        "name": "mock",
-        "version": "1",
+        "name": "mock_high",
+        "version": "2",
         "parameters": {},
     }
+    assert details["skill_search"] == [
+        {"skill_name": "mock_low", "version": "1", "parameters": {}, "score": 0.2},
+        {"skill_name": "mock_high", "version": "2", "parameters": {}, "score": 0.9},
+    ]
 
 
 @pytest.mark.parametrize("event_type", [ISSUE_DETECTED, TICKET_RECEIVED])


### PR DESCRIPTION
## Summary
- choose highest scoring skill from librarian search and include top-k in diagnosis details
- verify event flow recommends highest scoring skill
- test agent selection logic for highest scoring results

## Testing
- `pytest tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_existing_skill tests/integration/test_archaeologist_event_flow.py::test_archaeologist_recommends_skill_without_git_ops -q`

------
https://chatgpt.com/codex/tasks/task_e_6892200a161c832f837adca916862598