### PR TITLE
Include skill description in recommendations

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -165,9 +165,15 @@ class Archaeologist:
             call_name = f"skill_{skill['skill_name']}_v{skill['version']}"
             params = skill.get("parameters", {})
             param_list = ", ".join(params.keys()) if params else "no parameters"
-            skill_rec = _(
-                "Issue can be solved by invoking {call_name} with parameters: {param_list}."
-            ).format(call_name=call_name, param_list=param_list)
+            desc = skill.get("description")
+            if desc:
+                skill_rec = _(
+                    "Issue can be solved by invoking {call_name} ({desc}) with parameters: {param_list}."
+                ).format(call_name=call_name, desc=desc, param_list=param_list)
+            else:
+                skill_rec = _(
+                    "Issue can be solved by invoking {call_name} with parameters: {param_list}."
+                ).format(call_name=call_name, param_list=param_list)
             details["recommended_skill"] = {
                 "name": skill["skill_name"],
                 "version": skill["version"],

--- a/tests/integration/test_archaeologist_event_flow.py
+++ b/tests/integration/test_archaeologist_event_flow.py
@@ -26,12 +26,14 @@ def test_archaeologist_recommends_skill_without_git_ops(monkeypatch, use_librari
                     "version": "1",
                     "parameters": {"path": "str"},
                     "score": 0.1,
+                    "description": "Low scoring skill",
                 },
                 {
                     "skill_name": "sample_high",
                     "version": "2",
                     "parameters": {"path": "str"},
                     "score": 0.9,
+                    "description": "High scoring skill",
                 },
             ]
 
@@ -87,15 +89,18 @@ def test_archaeologist_recommends_skill_without_git_ops(monkeypatch, use_librari
                 "version": "1",
                 "parameters": {"path": "str"},
                 "score": 0.1,
+                "description": "Low scoring skill",
             },
             {
                 "skill_name": "sample_high",
                 "version": "2",
                 "parameters": {"path": "str"},
                 "score": 0.9,
+                "description": "High scoring skill",
             },
         ]
         assert "skill_sample_high_v2" in diag.actionable_recommendations
+        assert "High scoring skill" in diag.actionable_recommendations
     else:
         assert diag.details["recommended_skill"] is None
         assert "skill_sample_high_v2" not in diag.actionable_recommendations

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -70,7 +70,6 @@ def test_archaeologist_agent_diagnosis_complete(
     tmp_path: Path, event_type: str
 ) -> None:
     message_queue = MessageQueue()
-    Archaeologist(message_queue)
 
     received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
@@ -93,6 +92,7 @@ def test_archaeologist_agent_diagnosis_complete(
         return SimpleNamespace(stdout="", stderr="")
 
     with (
+        patch("autogpt.skills.library.get_embedding", lambda _t, _c: [0.1, 0.2, 0.3]),
         patch.object(arch_module.subprocess, "run", side_effect=fake_run) as mock_run,
         patch.object(dep_module.metadata, "version", return_value="1.0"),
         patch.object(
@@ -113,10 +113,12 @@ def test_archaeologist_agent_diagnosis_complete(
                     "skill_name": "sample_skill",
                     "version": "1",
                     "parameters": {"path": "str"},
+                    "description": "Tool that inspects sample files",
                 }
             ],
         ),
     ):
+        Archaeologist(message_queue)
         payload = {
             "plugin": "test_plugin",
             "error_log": (
@@ -145,6 +147,7 @@ def test_archaeologist_agent_diagnosis_complete(
         in diag.actionable_recommendations
     )
     assert "skill_sample_skill_v1" in diag.actionable_recommendations
+    assert "Tool that inspects sample files" in diag.actionable_recommendations
     assert diag.details is not None
     details = cast(dict[str, Any], diag.details)
     blame = details["blame"]
@@ -165,7 +168,6 @@ def test_archaeologist_agent_uses_dependency_new_version(
     tmp_path: Path, event_type: str
 ) -> None:
     message_queue = MessageQueue()
-    Archaeologist(message_queue)
 
     received: list[DiagnosisComplete] = []
     message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
@@ -192,11 +194,13 @@ def test_archaeologist_agent_uses_dependency_new_version(
         return ""
 
     with (
+        patch("autogpt.skills.library.get_embedding", lambda _t, _c: [0.1, 0.2, 0.3]),
         patch.object(arch_module.subprocess, "run", side_effect=fake_run),
         patch.object(dep_module.metadata, "version", return_value="1.0"),
         patch.object(dep_module, "fetch_release_notes", side_effect=fake_fetch),
         patch.object(arch_module.LibrarianAgent, "find_skill", return_value=[]),
     ):
+        Archaeologist(message_queue)
         payload = {
             "plugin": "test_plugin",
             "error_log": (
@@ -230,8 +234,20 @@ def test_on_issue_detected_recommends_existing_skill(event_type: str) -> None:
 
     with patch.object(arch_module, "LibrarianAgent") as MockLib:
         MockLib.return_value.find_skill.return_value = [
-            {"skill_name": "mock_low", "version": "1", "parameters": {}, "score": 0.2},
-            {"skill_name": "mock_high", "version": "2", "parameters": {}, "score": 0.9},
+            {
+                "skill_name": "mock_low",
+                "version": "1",
+                "parameters": {},
+                "score": 0.2,
+                "description": "Lower score skill",
+            },
+            {
+                "skill_name": "mock_high",
+                "version": "2",
+                "parameters": {},
+                "score": 0.9,
+                "description": "Higher score skill",
+            },
         ]
         Archaeologist(message_queue)
 
@@ -248,6 +264,7 @@ def test_on_issue_detected_recommends_existing_skill(event_type: str) -> None:
     assert len(received) == 1
     diag = received[0]
     assert "skill_mock_high_v2" in diag.actionable_recommendations
+    assert "Higher score skill" in diag.actionable_recommendations
     assert diag.details is not None
     details = cast(dict[str, Any], diag.details)
     assert details["recommended_skill"] == {
@@ -256,8 +273,20 @@ def test_on_issue_detected_recommends_existing_skill(event_type: str) -> None:
         "parameters": {},
     }
     assert details["skill_search"] == [
-        {"skill_name": "mock_low", "version": "1", "parameters": {}, "score": 0.2},
-        {"skill_name": "mock_high", "version": "2", "parameters": {}, "score": 0.9},
+        {
+            "skill_name": "mock_low",
+            "version": "1",
+            "parameters": {},
+            "score": 0.2,
+            "description": "Lower score skill",
+        },
+        {
+            "skill_name": "mock_high",
+            "version": "2",
+            "parameters": {},
+            "score": 0.9,
+            "description": "Higher score skill",
+        },
     ]
 
 


### PR DESCRIPTION
## Summary
- use any available skill description when composing actionable recommendations
- track description text in test expectations

## Testing
- `pytest tests/unit/test_archaeologist_agent.py tests/integration/test_archaeologist_event_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_689224264244832f835bd801d3519137