### PR TITLE
Retain plugin metadata in diagnostic events

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -110,6 +110,7 @@ class Archaeologist:
                 "context": context,
                 "dependencies": analysis.get("dependencies"),
             }
+            details["plugin"] = plugin_id
             if description:
                 details["description"] = description
 
@@ -136,6 +137,7 @@ class Archaeologist:
                 "error_log": error_log,
                 "dependencies": analysis.get("dependencies"),
             }
+            details["plugin"] = plugin_id
             if description:
                 details["description"] = description
         else:

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -101,6 +101,7 @@ class DiagnosisDetails(TypedDict, total=False):
     """Extra information included with :class:`DiagnosisComplete`."""
 
     recommended_skill: RecommendedSkill | None
+    plugin: str | None
     # other optional fields such as ``skill_search`` or ``metadata`` may appear
 
 
@@ -116,9 +117,10 @@ class DiagnosisComplete(EventMessage):
 
     def __post_init__(self) -> None:
         if self.details is None:
-            self.details = {"recommended_skill": None}
+            self.details = {"recommended_skill": None, "plugin": None}
         else:
             self.details.setdefault("recommended_skill", None)
+            self.details.setdefault("plugin", None)
 
         rec = self.details.get("recommended_skill")
         if isinstance(rec, dict):

--- a/tests/integration/test_archaeologist_event_flow.py
+++ b/tests/integration/test_archaeologist_event_flow.py
@@ -75,6 +75,7 @@ def test_archaeologist_recommends_skill_without_git_ops(monkeypatch, use_librari
     assert calls == []
     assert len(received) == 1
     diag = received[0]
+    assert diag.details["plugin"] == "example_plugin"
     if use_librarian:
         assert diag.details["recommended_skill"] == {
             "name": "sample_high",

--- a/tests/unit/test_archaeologist.py
+++ b/tests/unit/test_archaeologist.py
@@ -66,6 +66,7 @@ def test_archaeologist_handles_issue(
     assert any(c["line"] == 10 for c in details["context"])
     assert isinstance(details["dependencies"], list)
     assert details["recommended_skill"] is None
+    assert details["plugin"] == "test_plugin"
 
 
 @pytest.mark.parametrize("event_type", [ISSUE_DETECTED, TICKET_RECEIVED])

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -45,6 +45,7 @@ def test_message_queue_diagnosis_complete(message_queue: MessageQueue) -> None:
     event = DiagnosisComplete(
         summary="Diagnostics complete",
         actionable_recommendations="Fix it",
+        details={"plugin": "example_plugin"},
         source_agent="archaeologist",
     )
     message_queue.publish(event)
@@ -53,12 +54,14 @@ def test_message_queue_diagnosis_complete(message_queue: MessageQueue) -> None:
     assert isinstance(received[0], DiagnosisComplete)
     assert received[0].summary == "Diagnostics complete"
     assert received[0].details["recommended_skill"] is None
+    assert received[0].details["plugin"] == "example_plugin"
 
     events = list(message_queue.get_events())
     assert len(events) == 1
     assert isinstance(events[0], DiagnosisComplete)
     assert events[0].summary == "Diagnostics complete"
     assert events[0].details["recommended_skill"] is None
+    assert events[0].details["plugin"] == "example_plugin"
 
 
 def test_message_queue_diagnosis_complete_recommended_skill(
@@ -71,6 +74,7 @@ def test_message_queue_diagnosis_complete_recommended_skill(
         summary="Diagnostics complete",
         actionable_recommendations="Invoke skill",
         details={
+            "plugin": "example_plugin",
             "recommended_skill": {
                 "name": "skill_example",
                 "version": "1",
@@ -87,6 +91,7 @@ def test_message_queue_diagnosis_complete_recommended_skill(
         "version": "1",
         "parameters": {"path": "str"},
     }
+    assert received[0].details["plugin"] == "example_plugin"
 
 
 def test_message_queue_publish_from_multiple_sources(


### PR DESCRIPTION
## Summary
- Preserve `plugin` metadata in `DiagnosisComplete` event details
- Include plugin info when Archaeologist builds diagnostics
- Expand tests to assert plugin data is carried through

## Testing
- `pytest tests/unit/test_event_bus.py::test_message_queue_diagnosis_complete tests/unit/test_event_bus.py::test_message_queue_diagnosis_complete_recommended_skill tests/integration/test_archaeologist_event_flow.py::test_archaeologist_recommends_skill_without_git_ops[True] tests/integration/test_archaeologist_event_flow.py::test_archaeologist_recommends_skill_without_git_ops[False] tests/unit/test_archaeologist.py::test_archaeologist_handles_issue[False-ISSUE_DETECTED] tests/unit/test_archaeologist.py::test_archaeologist_handles_issue[False-TICKET_RECEIVED] tests/unit/test_archaeologist.py::test_archaeologist_parses_python_traceback[False-ISSUE_DETECTED] tests/unit/test_archaeologist.py::test_archaeologist_parses_python_traceback[False-TICKET_RECEIVED] tests/unit/test_archaeologist.py::test_archaeologist_parses_plugin_log[False-ISSUE_DETECTED] tests/unit/test_archaeologist.py::test_archaeologist_parses_plugin_log[False-TICKET_RECEIVED] tests/unit/test_archaeologist.py::test_archaeologist_parsing_fails_gracefully[False-ISSUE_DETECTED] tests/unit/test_archaeologist.py::test_archaeologist_parsing_fails_gracefully[False-TICKET_RECEIVED] -q`

------
https://chatgpt.com/codex/tasks/task_e_6892241033c0832fb22a8576e557f596