### PR TITLE
feat: add new skill metadata generation

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 import re
+import json
 
 from git import Repo  # type: ignore[import-not-found]
 
@@ -126,11 +127,60 @@ class TDDDeveloper:
         if not isinstance(payload, dict):
             return
 
-        issue_id = payload.get("issue_id")
         repo_path = payload.get("repo_path")
-        diagnostics: Any = payload.get("diagnostics") or payload.get("details")
+        details = payload.get("details", {})
+        diagnostics: Any = payload.get("diagnostics") or details
 
-        if not issue_id or not repo_path:
+        if not repo_path:
+            return
+
+        new_skill = details.get("new_skill") if isinstance(details, dict) else None
+        if new_skill:
+            name = new_skill.get("skill_name") or new_skill.get("name")
+            version = new_skill.get("version", "1.0")
+            branch = f"new-skill/{name}_{version}"
+            git_create_branch(repo_path, branch, self.agent)
+            git_checkout(repo_path, branch, self.agent)
+
+            skill_dir = Path(repo_path) / "skill_library" / f"{name}_{version}"
+            code = new_skill.get("code", "")
+            write_to_file(str(skill_dir / "main.py"), code, self.agent)
+            metadata = {
+                "skill_name": name,
+                "version": version,
+                "description": new_skill.get("description", ""),
+                "tags": new_skill.get("tags", []),
+                "parameters": new_skill.get("parameters", {}),
+            }
+            for key in [
+                "dependencies_file",
+                "entry_point",
+                "return_type",
+                "author_agent",
+                "creation_timestamp",
+            ]:
+                if new_skill.get(key) is not None:
+                    metadata[key] = new_skill[key]
+            write_to_file(
+                str(skill_dir / "skill.json"), json.dumps(metadata, indent=2), self.agent
+            )
+            git_commit(repo_path, f"Add new skill {name}", self.agent)
+            try:
+                commit_hash = Repo(repo_path).head.commit.hexsha
+            except Exception:
+                commit_hash = ""
+            self.message_queue.publish(
+                CodeFixProposed(
+                    branch_name=branch,
+                    commit_hash=commit_hash,
+                    summary=f"Add new skill {name}",
+                    source_agent="tdd_developer",
+                )
+            )
+            return
+
+        issue_id = payload.get("issue_id")
+        if not issue_id:
             return
 
         branch = f"fix/{issue_id}"
@@ -138,9 +188,7 @@ class TDDDeveloper:
         git_checkout(repo_path, branch, self.agent)
 
         recommended_skill = (
-            payload.get("details", {}).get("recommended_skill")
-            if isinstance(payload.get("details"), dict)
-            else None
+            details.get("recommended_skill") if isinstance(details, dict) else None
         )
         if recommended_skill:
             self._use_recommended_skill(repo_path, branch, issue_id, recommended_skill)

--- a/tests/unit/test_tdd_developer_agent.py
+++ b/tests/unit/test_tdd_developer_agent.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 import types
 from pathlib import Path
+import json
 
 from autogpt.event_bus import CODE_FIX_PROPOSED, DIAGNOSIS_COMPLETE, EventMessage
 
@@ -138,3 +139,58 @@ def test_tdd_developer_agent_flow(tmp_path, mocker):
     assert published_event.payload["branch_name"] == "fix/123"
     assert published_event.payload["summary"] == "Fix issue 123"
     assert published_event.payload["commit_hash"] == ""
+
+
+def test_tdd_developer_creates_new_skill(tmp_path, mocker):
+    message_queue = mocker.Mock(spec=["subscribe", "publish"])
+    agent = Agent()
+
+    TDDDeveloper(agent=agent, message_queue=message_queue)
+
+    message_queue.subscribe.assert_called_once()
+    _, callback = message_queue.subscribe.call_args[0]
+
+    create_branch = mocker.patch.object(
+        tdd_module, "git_create_branch", return_value=""
+    )
+    checkout = mocker.patch.object(tdd_module, "git_checkout", return_value="")
+    commit = mocker.patch.object(tdd_module, "git_commit", return_value="")
+
+    def fake_write(path: str, content: str, *_: object) -> str:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(content)
+        return ""
+
+    writer = mocker.patch.object(tdd_module, "write_to_file", side_effect=fake_write)
+
+    repo_path = str(tmp_path)
+    new_skill = {
+        "skill_name": "skill_test",
+        "version": "1.0",
+        "description": "Test skill",
+        "parameters": {},
+        "tags": ["test"],
+        "code": "def run() -> str:\n    return 'ok'\n",
+    }
+    event = EventMessage(
+        event_type=DIAGNOSIS_COMPLETE,
+        payload={"repo_path": repo_path, "details": {"new_skill": new_skill}},
+        source_agent="tester",
+    )
+
+    callback(event)
+
+    create_branch.assert_called_once_with(repo_path, "new-skill/skill_test_1.0", agent)
+    checkout.assert_called_once_with(repo_path, "new-skill/skill_test_1.0", agent)
+    commit.assert_called_once_with(repo_path, "Add new skill skill_test", agent)
+
+    skill_dir = Path(repo_path) / "skill_library" / "skill_test_1.0"
+    assert (skill_dir / "main.py").read_text() == new_skill["code"]
+    metadata = json.loads((skill_dir / "skill.json").read_text())
+    assert metadata["skill_name"] == "skill_test"
+    assert metadata["version"] == "1.0"
+
+    message_queue.publish.assert_called_once()
+    published_event = message_queue.publish.call_args[0][0]
+    assert published_event.payload["branch_name"] == "new-skill/skill_test_1.0"
+    assert published_event.payload["summary"] == "Add new skill skill_test"


### PR DESCRIPTION
## Summary
- support creating new skill metadata and code when diagnosis recommends a new skill
- test new-skill workflow for TDD developer agent

## Testing
- `pytest tests/unit/test_tdd_developer_agent.py::test_tdd_developer_creates_new_skill -q`


------
https://chatgpt.com/codex/tasks/task_e_68922f16d468832fb8d39b745f1462dc