### PR TITLE
Add TDDDeveloper skill handling tests

### DIFF
--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -172,7 +172,7 @@ def test_tdd_developer_generates_repro_test(
     assert "pytest.raises(ValueError)" in content
 
 
-def test_tdd_developer_handles_recommended_skill(
+def test_tdd_developer_handles_recommended_skill_without_fix_loop(
     agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
 ) -> None:
     event_bus = EventBus(tmp_path / "events.db")
@@ -182,21 +182,30 @@ def test_tdd_developer_handles_recommended_skill(
     mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")
     mocker.patch("autogpt.agents.tdd_developer.git_checkout", return_value="")
     write_file = mocker.patch(
-        "autogpt.agents.tdd_developer.write_to_file", return_value=""
+        "autogpt.agents.tdd_developer.write_to_file", return_value="",
     )
     create_test = mocker.patch(
-        "autogpt.agents.tdd_developer.create_test_file", return_value=""
+        "autogpt.agents.tdd_developer.create_test_file", return_value="",
     )
+
+    repo_path = str(workspace.root)
+    script_path = Path(repo_path) / "scripts" / "use_hello_world.py"
+    test_path = Path(repo_path) / "tests" / "test_use_hello_world.py"
+
+    run_paths: list[str] = []
+
+    def capture_run(path: str, *_: object) -> dict[str, int]:
+        run_paths.append(path)
+        return {"exit_code": 0}
+
     run = mocker.patch(
-        "autogpt.agents.tdd_developer.run_tests",
-        return_value={"exit_code": 0},
+        "autogpt.agents.tdd_developer.run_tests", side_effect=capture_run
     )
     commit = mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
 
     received: list[EventMessage] = []
     message_queue.subscribe(CODE_FIX_PROPOSED, lambda msg: received.append(msg))
 
-    repo_path = str(workspace.root)
     payload = {
         "issue_id": "99",
         "repo_path": repo_path,
@@ -215,12 +224,61 @@ def test_tdd_developer_handles_recommended_skill(
         )
     )
 
-    script_path = Path(repo_path) / "scripts" / "use_hello_world.py"
-    test_path = Path(repo_path) / "tests" / "test_use_hello_world.py"
     write_file.assert_called_once_with(str(script_path), ANY, agent)
     create_test.assert_called_once_with(str(test_path), ANY, agent)
-    run.assert_called_once_with(str(test_path), agent)
+    assert run_paths == [str(test_path)]
     commit.assert_called_once_with(repo_path, "Use recommended skill hello_world", agent)
     assert len(received) == 1
     assert received[0].payload["branch_name"] == "fix/99"
     assert received[0].payload["summary"] == "Use recommended skill hello_world"
+
+
+def test_tdd_developer_adds_new_skill(
+    agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    TDDDeveloper(agent=agent, message_queue=message_queue)
+
+    create_branch = mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")
+    checkout = mocker.patch("autogpt.agents.tdd_developer.git_checkout", return_value="")
+    write_file = mocker.patch("autogpt.agents.tdd_developer.write_to_file", return_value="")
+    run = mocker.patch("autogpt.agents.tdd_developer.run_tests")
+    commit = mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
+
+    repo_obj = types.SimpleNamespace(head=types.SimpleNamespace(commit=types.SimpleNamespace(hexsha="abc123")))
+    mocker.patch("autogpt.agents.tdd_developer.Repo", return_value=repo_obj)
+
+    received: list[EventMessage] = []
+    message_queue.subscribe(CODE_FIX_PROPOSED, lambda msg: received.append(msg))
+
+    repo_path = str(workspace.root)
+    payload = {
+        "repo_path": repo_path,
+        "details": {
+            "new_skill": {
+                "skill_name": "awesome",
+                "version": "1.0",
+                "code": "def run(): pass",
+            }
+        },
+    }
+
+    message_queue.publish(
+        EventMessage(
+            event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+        )
+    )
+
+    branch = 'new-skill/awesome_1.0'
+    create_branch.assert_called_once_with(repo_path, branch, agent)
+    checkout.assert_called_once_with(repo_path, branch, agent)
+    skill_dir = Path(repo_path) / "skill_library" / "awesome_1.0"
+    write_file.assert_any_call(str(skill_dir / "main.py"), "def run(): pass", agent)
+    write_file.assert_any_call(str(skill_dir / "skill.json"), ANY, agent)
+    assert write_file.call_count == 2
+    commit.assert_called_once_with(repo_path, "Add new skill awesome", agent)
+    run.assert_not_called()
+    assert len(received) == 1
+    assert received[0].payload["branch_name"] == "new-skill/awesome_1.0"
+    assert received[0].payload["summary"] == "Add new skill awesome"


### PR DESCRIPTION
## Summary
- test that recommended skills create a usage script and test without entering the fix loop
- test that new skills generate `skill.json` and `main.py` and commit the change

## Testing
- `pytest tests/unit/test_tdd_developer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68923f5dd85c832fb1b415ce3c0f2598