### PR TITLE
feat: register new skills with librarian

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -19,14 +19,27 @@ from autogpt.event_bus import (
     EventMessage,
     MessageQueue,
 )
+from autogpt.skills.librarian import LibrarianAgent
 
 
 class TDDDeveloper:
-    """Agent that creates failing tests and proposes fixes based on diagnostics."""
+    """Agent that creates failing tests and proposes fixes based on diagnostics.
 
-    def __init__(self, agent: Agent, message_queue: MessageQueue) -> None:
+    Args:
+        agent: The ``Agent`` used for executing commands.
+        message_queue: Queue for communication with other agents.
+        librarian: Optional ``LibrarianAgent`` for registering new skills.
+    """
+
+    def __init__(
+        self,
+        agent: Agent,
+        message_queue: MessageQueue,
+        librarian: LibrarianAgent | None = None,
+    ) -> None:
         self.agent = agent
         self.message_queue = message_queue
+        self.librarian = librarian
         self.message_queue.subscribe(DIAGNOSIS_COMPLETE, self._on_diagnosis_complete)
 
     # ------------------------------------------------------------------
@@ -164,6 +177,8 @@ class TDDDeveloper:
             write_to_file(
                 str(skill_dir / "skill.json"), json.dumps(metadata, indent=2), self.agent
             )
+            if self.librarian:
+                self.librarian.add_skill(metadata, str(skill_dir / "main.py"))
             git_commit(repo_path, f"Add new skill {name}", self.agent)
             try:
                 commit_hash = Repo(repo_path).head.commit.hexsha

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -238,7 +238,8 @@ def test_tdd_developer_adds_new_skill(
 ) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
-    TDDDeveloper(agent=agent, message_queue=message_queue)
+    librarian = mocker.Mock()
+    TDDDeveloper(agent=agent, message_queue=message_queue, librarian=librarian)
 
     create_branch = mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")
     checkout = mocker.patch("autogpt.agents.tdd_developer.git_checkout", return_value="")
@@ -277,6 +278,14 @@ def test_tdd_developer_adds_new_skill(
     write_file.assert_any_call(str(skill_dir / "main.py"), "def run(): pass", agent)
     write_file.assert_any_call(str(skill_dir / "skill.json"), ANY, agent)
     assert write_file.call_count == 2
+    expected_metadata = {
+        "skill_name": "awesome",
+        "version": "1.0",
+        "description": "",
+        "tags": [],
+        "parameters": {},
+    }
+    librarian.add_skill.assert_called_once_with(expected_metadata, str(skill_dir / "main.py"))
     commit.assert_called_once_with(repo_path, "Add new skill awesome", agent)
     run.assert_not_called()
     assert len(received) == 1


### PR DESCRIPTION
## Summary
- allow TDDDeveloper to accept optional LibrarianAgent
- register newly created skills with the librarian
- cover librarian registration in tests

## Testing
- `pytest tests/unit/test_tdd_developer.py`

------
https://chatgpt.com/codex/tasks/task_e_68924fb882b8832fafde316812750ed0