### PR TITLE
Add manual skill registration step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,3 +259,30 @@ jobs:
         with:
           name: test-logs
           path: logs/
+
+  register_new_skills:
+    needs: [lint, test]
+    if: ${{ startsWith(github.event_name, 'pull_request') }}
+    runs-on: ubuntu-latest
+    environment: manual-approval
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install faiss-cpu
+
+      - name: Register new skills
+        run: python scripts/register_new_skills.py

--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ python scripts/skill_cli.py test my_skill
 
 请阅读 [贡献指南](CONTRIBUTING-zh.md) 与 [行为准则](CODE_OF_CONDUCT-zh.md) 了解如何参与本项目。
 
+在提交新的技能（包含 `skill.json`）时，CI 流程将在测试通过后暂停，等待维护者人工批准。
+批准后会运行 `python scripts/register_new_skills.py` 自动注册新增技能。
+请确保元数据与代码文件正确，以便顺利完成注册。
+
 ## 💖 资助 Auto-GPT 的开发
 
 如果你愿意请我们喝杯咖啡，你的支持将帮助我们承担 Auto-GPT 的开发成本并推动全自动 AI 的边界！

--- a/scripts/register_new_skills.py
+++ b/scripts/register_new_skills.py
@@ -1,0 +1,76 @@
+"""Register newly added skills in the repository.
+
+This script scans the Git history for any ``skill.json`` files that were
+added in the current branch compared to the base branch. For each newly
+added ``skill.json`` file it invokes ``librarian.add_skill(metadata, code_path)``
+so the skill is stored in the local skill library.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from autogpt.skills import LibrarianAgent
+
+
+def _get_base_ref() -> str:
+    """Return the git ref to compare the current branch against."""
+    base_branch = os.environ.get("GITHUB_BASE_REF", "master")
+    return f"origin/{base_branch}"
+
+
+def find_new_skill_files(base_ref: str) -> list[Path]:
+    """Return paths to ``skill.json`` files added since ``base_ref``."""
+    diff_cmd = [
+        "git",
+        "diff",
+        "--name-status",
+        f"{base_ref}...HEAD",
+        "--",
+        "*skill.json",
+    ]
+    try:
+        result = subprocess.run(diff_cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError:
+        # Fallback to diffing against the previous commit if the base ref is
+        # unavailable (e.g. in a shallow clone)
+        fallback_cmd = ["git", "diff", "--name-status", "HEAD^", "--", "*skill.json"]
+        result = subprocess.run(
+            fallback_cmd, capture_output=True, text=True, check=True
+        )
+
+    added: list[Path] = []
+    for line in result.stdout.splitlines():
+        status, path = line.split("\t", 1)
+        if status == "A":
+            added.append(Path(path))
+    return added
+
+
+def register_skill(skill_json: Path, librarian: LibrarianAgent) -> None:
+    """Register a single skill given its ``skill.json`` file."""
+    metadata = json.loads(skill_json.read_text(encoding="utf-8"))
+    code_path = skill_json.parent / metadata.get("entry_point", "main.py")
+    if librarian.add_skill(metadata, str(code_path)):
+        print(f"Registered skill from {skill_json}")
+    else:
+        print(f"Failed to register skill from {skill_json}")
+
+
+def main() -> None:
+    base_ref = _get_base_ref()
+    new_skills = find_new_skill_files(base_ref)
+    if not new_skills:
+        print("No new skills to register")
+        return
+
+    librarian = LibrarianAgent()
+    for skill_file in new_skills:
+        register_skill(skill_file, librarian)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `register_new_skills.py` script to find newly added `skill.json` files and register them with the librarian
- require manual approval in CI before running the skill registration script
- document the approval and registration step in the README

## Testing
- `flake8 scripts/register_new_skills.py`
- `isort scripts/register_new_skills.py`
- `black scripts/register_new_skills.py`
- `pytest tests/unit/test_skill_library.py tests/unit/test_librarian_agent.py -q`
- `python scripts/register_new_skills.py`

------
https://chatgpt.com/codex/tasks/task_e_68925ecdcc10832fa51c6ad2a6633659