### PR TITLE
Add logging and exception handling to Librarian add_skill

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -95,13 +95,14 @@ class LibrarianAgent:
 
         try:
             metadata = SkillMetadata(**skill_metadata)
-        except TypeError:
-            # Provided metadata does not match the expected schema
-            return False
+        except TypeError as err:
+            logger.error(f"Invalid skill metadata: {err}")
+            raise ValueError("Invalid skill metadata") from err
 
         source = Path(skill_code_path)
         if not source.is_file():
-            return False
+            logger.error(f"Skill code path is not a file: {source}")
+            raise FileNotFoundError(f"Skill code path is not a file: {source}")
 
         # Copy the code into the skill library directory
         dest_dir = (
@@ -113,8 +114,11 @@ class LibrarianAgent:
             dest_file = dest_dir / "main.py"
             shutil.copy2(source, dest_file)
             code = dest_file.read_text(encoding="utf-8")
-        except OSError:
-            return False
+        except OSError as err:
+            logger.error(
+                f"Failed to copy skill code from {source} to {dest_dir}: {err}"
+            )
+            raise
 
         try:
             self.skill_library.add_skill(
@@ -131,5 +135,10 @@ class LibrarianAgent:
                 creation_timestamp=metadata.creation_timestamp,
             )
             return True
-        except Exception:
-            return False
+        except Exception as err:
+            logger.error(
+                f"Failed to register skill {metadata.skill_name}: {err}"
+            )
+            raise RuntimeError(
+                f"Failed to register skill {metadata.skill_name}"
+            ) from err

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -51,8 +51,8 @@ def test_add_and_find_skill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert results == [metadata]
 
 
-def test_add_skill_invalid_metadata_returns_false(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_add_skill_invalid_metadata_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     agent = _setup_agent(tmp_path, monkeypatch)
     code_file = tmp_path / "skill.py"
@@ -61,18 +61,24 @@ def test_add_skill_invalid_metadata_returns_false(
     metadata = _metadata()
     metadata.pop("skill_name")
 
-    assert agent.add_skill(metadata, str(code_file)) is False
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ValueError):
+            agent.add_skill(metadata, str(code_file))
+    assert any("Invalid skill metadata" in rec.title for rec in caplog.records)
 
 
-def test_add_skill_missing_code_path_returns_false(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_add_skill_missing_code_path_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     agent = _setup_agent(tmp_path, monkeypatch)
 
     metadata = _metadata()
     missing_path = tmp_path / "missing.py"
 
-    assert agent.add_skill(metadata, str(missing_path)) is False
+    with caplog.at_level("ERROR"):
+        with pytest.raises(FileNotFoundError):
+            agent.add_skill(metadata, str(missing_path))
+    assert any("Skill code path is not a file" in rec.title for rec in caplog.records)
 
 
 def test_find_skill_caches_results(

--- a/tests/unit/test_skill_library.py
+++ b/tests/unit/test_skill_library.py
@@ -8,6 +8,8 @@ from typing import Dict, List
 import pytest
 
 from autogpt.config import Config
+from autogpt.skills import library as library_module
+from autogpt.skills.librarian import LibrarianAgent
 
 
 def make_embedding_map() -> Dict[str, List[float]]:
@@ -248,3 +250,70 @@ def test_git_commit_reports_push_failure(
     library.add_skill("s", "1.0", "code", {}, "d", ["t"])
 
     assert any("Error: push failed" in p for p in printed)
+
+
+# ---------------------------------------------------------------------------
+def _setup_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LibrarianAgent:
+    monkeypatch.setattr(
+        "autogpt.skills.library.get_embedding", lambda _text, _config: [0.1, 0.2, 0.3]
+    )
+    monkeypatch.setattr(
+        "autogpt.skills.librarian.SkillLibrary",
+        lambda config: library_module.SkillLibrary(config, storage_path=tmp_path),
+    )
+    return LibrarianAgent(Config())
+
+
+def _metadata() -> dict:
+    return {
+        "skill_name": "test_skill",
+        "version": "1.0",
+        "description": "Test skill",
+        "tags": ["test"],
+        "parameters": {"param": "value"},
+        "dependencies_file": "requirements.txt",
+        "entry_point": "main:run",
+        "return_type": "str",
+        "author_agent": "tester",
+        "creation_timestamp": "2024-01-01T00:00:00Z",
+    }
+
+
+def test_librarian_add_skill_invalid_metadata_logs_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+    code_file = tmp_path / "skill.py"
+    code_file.write_text("def run():\n    return 'hello'\n")
+
+    metadata = _metadata()
+    metadata.pop("skill_name")
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ValueError):
+            agent.add_skill(metadata, str(code_file))
+    assert any("Invalid skill metadata" in rec.title for rec in caplog.records)
+
+
+def test_librarian_add_skill_copy_failure_logs_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    agent = _setup_agent(tmp_path, monkeypatch)
+    code_file = tmp_path / "skill.py"
+    code_file.write_text("def run():\n    return 'hello'\n")
+
+    metadata = _metadata()
+
+    def boom(*_args, **_kwargs) -> None:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr("autogpt.skills.librarian.shutil.copy2", boom)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(OSError):
+            agent.add_skill(metadata, str(code_file))
+    assert any("Failed to copy skill code" in rec.title for rec in caplog.records)

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -299,7 +299,7 @@ def test_tdd_developer_aborts_on_failed_add_skill(
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
     librarian = mocker.Mock()
-    librarian.add_skill.return_value = False
+    librarian.add_skill.side_effect = RuntimeError("failure")
     TDDDeveloper(agent=agent, message_queue=message_queue, librarian=librarian)
 
     mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")


### PR DESCRIPTION
## Summary
- improve error reporting in `LibrarianAgent.add_skill` with `logger.error` messages and explicit exceptions
- test failure paths when validation fails or code copy fails
- update unit tests to expect exceptions from `add_skill`

## Testing
- `pytest tests/unit/test_librarian_agent.py tests/unit/test_skill_library.py tests/unit/test_tdd_developer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689267f140c8832f9bd0205c0a52b6af