### PR TITLE
chore: rename OPENAI_BASE_URL variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,10 +25,10 @@ OPENAI_API_KEY=your-openai-api-key
 ## PROMPT_SETTINGS_FILE - Specifies which Prompt Settings file to use, relative to the Auto-GPT root directory. (defaults to prompt_settings.yaml)
 # PROMPT_SETTINGS_FILE=prompt_settings.yaml
 
-## OPENAI_BASE_URL - Custom url for the OpenAI API, useful for connecting to
+## OPENAI_API_BASE_URL - Custom url for the OpenAI API, useful for connecting to
 ## custom backends or local proxies. Leave blank to use the official endpoint.
 # the following is an example:
-# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_BASE_URL=http://localhost:8080/v1
 
 ## OPENAI_FUNCTIONS - Enables OpenAI functions: https://platform.openai.com/docs/guides/gpt/function-calling
 ## WARNING: this feature is only supported by OpenAI's newest models. Until these models become the default on 27 June, add a '-0613' suffix to the model of your choosing.

--- a/.env.template-zh
+++ b/.env.template-zh
@@ -25,9 +25,9 @@ OPENAI_API_KEY=your-openai-api-key
 ## PROMPT_SETTINGS_FILE - 指定要使用的提示设置文件，相对于 Auto-GPT 根目录。（默认：prompt_settings.yaml）
 # PROMPT_SETTINGS_FILE=prompt_settings.yaml
 
-## OPENAI_BASE_URL - OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
+## OPENAI_API_BASE_URL - OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
 # 以下为示例：
-# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_BASE_URL=http://localhost:8080/v1
 
 ## OPENAI_FUNCTIONS - 启用 OpenAI Functions：https://platform.openai.com/docs/guides/gpt/function-calling
 ## 警告：该功能仅支持 OpenAI 最新的模型。在这些模型于 6 月 27 日成为默认模型之前，请在所选模型名称后加上“-0613”后缀。

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -31,6 +31,7 @@
 - `MEMORY_BACKEND`：使用的记忆后端。目前支持 `json_file` 和 `chroma`。默认值：json_file
 - `MEMORY_INDEX`：在记忆后端中用于作用域、命名或索引的值。默认值：auto-gpt
 - `OPENAI_API_KEY`：**必填**——你的 [OpenAI API Key](https://platform.openai.com/account/api-keys)。
+- `OPENAI_API_BASE_URL`：OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
 - `OPENAI_ORGANIZATION`：OpenAI 组织 ID。可选。
 - `PLAIN_OUTPUT`：纯文本输出，禁用旋转指示器。默认值：False
 - `PLUGINS_CONFIG_FILE`：插件配置文件相对于 Auto-GPT 根目录的路径。默认值：plugins_config.yaml


### PR DESCRIPTION
## Summary
- rename OPENAI_BASE_URL to OPENAI_API_BASE_URL in env templates
- document OPENAI_API_BASE_URL option
- ensure no lingering OPENAI_BASE_URL references

## Testing
- `pre-commit run --files .env.template .env.template-zh docs/configuration/options.md` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_689326838750832fbb0b4ea82ff21305