### PR TITLE
docs: fix execute_local_commands default

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,8 +7,8 @@
 ## OPENAI_API_KEY - OpenAI API Key (Example: my-openai-api-key)
 OPENAI_API_KEY=your-openai-api-key
 
-## EXECUTE_LOCAL_COMMANDS - Allow local command execution (Default: False)
-# EXECUTE_LOCAL_COMMANDS=False
+## EXECUTE_LOCAL_COMMANDS - Allow local command execution (Default: True)
+# EXECUTE_LOCAL_COMMANDS=True
 
 ## RESTRICT_TO_WORKSPACE - Restrict file operations to workspace ./auto_gpt_workspace (Default: True)
 # RESTRICT_TO_WORKSPACE=True

--- a/.env.template-zh
+++ b/.env.template-zh
@@ -7,8 +7,8 @@
 ## OPENAI_API_KEY - OpenAI API 密钥（示例：my-openai-api-key）
 OPENAI_API_KEY=your-openai-api-key
 
-## EXECUTE_LOCAL_COMMANDS - 允许执行本地命令（默认：False）
-# EXECUTE_LOCAL_COMMANDS=False
+## EXECUTE_LOCAL_COMMANDS - 允许执行本地命令（默认：True）
+# EXECUTE_LOCAL_COMMANDS=True
 
 ## RESTRICT_TO_WORKSPACE - 将文件操作限制在工作区 ./auto_gpt_workspace（默认：True）
 # RESTRICT_TO_WORKSPACE=True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,12 +2,11 @@
 Test cases for the config class, which handles the configuration settings
 for the AI and ensures it behaves as a singleton.
 """
-import os
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest import mock
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,6 +26,15 @@ def test_initial_values(config: Config) -> None:
     assert config.fast_llm == "gpt-3.5-turbo"
     assert config.smart_llm == "gpt-4-0314"
     assert config.use_librarian is True
+
+
+def test_execute_local_commands_default_true(
+    monkeypatch: pytest.MonkeyPatch, workspace: Workspace
+) -> None:
+    """Ensure execute_local_commands defaults to True when unset."""
+    monkeypatch.delenv("EXECUTE_LOCAL_COMMANDS", raising=False)
+    config = ConfigBuilder.build_config_from_env(workspace.root.parent)
+    assert config.execute_local_commands is True
 
 
 def test_set_continuous_mode(config: Config) -> None:
@@ -273,7 +281,9 @@ def test_apply_overlay(tmp_path: Path, config: Config) -> None:
     assert config.fast_llm == "gpt-4"
 
 
-def test_build_config_from_env_use_librarian(workspace: Workspace, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_config_from_env_use_librarian(
+    workspace: Workspace, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("USE_LIBRARIAN", "False")
     config = ConfigBuilder.build_config_from_env(workspace.root.parent)
     assert config.use_librarian is False


### PR DESCRIPTION
## Summary
- clarify `EXECUTE_LOCAL_COMMANDS` default to True in both env templates
- test that `execute_local_commands` defaults to True when unset

## Testing
- `pre-commit run --files .env.template .env.template-zh tests/unit/test_config.py` (skipped: pytest-check)
- `pytest tests/unit/test_config.py::test_execute_local_commands_default_true -q`


------
https://chatgpt.com/codex/tasks/task_e_6893293477ec832fbf53bf36b2a44a52