### PR TITLE
chore: rename OpenAI organization variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,8 +53,8 @@ OPENAI_API_KEY=your-openai-api-key
 ## TEMPERATURE - Sets temperature in OpenAI (Default: 0)
 # TEMPERATURE=0
 
-## OPENAI_ORG_ID - Your OpenAI Organization key (Default: None)
-# OPENAI_ORG_ID=
+## OPENAI_ORGANIZATION - Your OpenAI Organization key (Default: None)
+# OPENAI_ORGANIZATION=
 
 ## AZURE_OPENAI_ENDPOINT - Your Azure OpenAI endpoint, e.g. "https://your-resource-name.openai.azure.com/"
 # AZURE_OPENAI_ENDPOINT=

--- a/.env.template-zh
+++ b/.env.template-zh
@@ -52,8 +52,8 @@ OPENAI_API_KEY=your-openai-api-key
 ## TEMPERATURE - 设置 OpenAI 的温度（默认：0）
 # TEMPERATURE=0
 
-## OPENAI_ORG_ID - 你的 OpenAI 组织 ID（默认：None）
-# OPENAI_ORG_ID=
+## OPENAI_ORGANIZATION - 你的 OpenAI 组织 ID（默认：None）
+# OPENAI_ORGANIZATION=
 
 ## AZURE_OPENAI_ENDPOINT - 你的 Azure OpenAI 终端地址，例如 "https://your-resource-name.openai.azure.com/"
 # AZURE_OPENAI_ENDPOINT=


### PR DESCRIPTION
## Summary
- rename OPENAI_ORG_ID to OPENAI_ORGANIZATION in env templates

## Testing
- `pre-commit run --files .env.template .env.template-zh` *(fails: ImportError: cannot import name 'AsyncAzureOpenAI' from 'openai')*
- `rg OPENAI_ORG_ID`


------
https://chatgpt.com/codex/tasks/task_e_68932928b404832f8537af841d4d5c72