### PR TITLE
docs: set openai/whisper-large-v2 as default STT model

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -165,8 +165,8 @@ OPENAI_API_KEY=your-openai-api-key
 ## AUDIO_TO_TEXT_PROVIDER - Audio-to-text provider (Default: huggingface)
 # AUDIO_TO_TEXT_PROVIDER=huggingface
 
-## HUGGINGFACE_AUDIO_TO_TEXT_MODEL - The model for HuggingFace to use (Default: CompVis/stable-diffusion-v1-4)
-# HUGGINGFACE_AUDIO_TO_TEXT_MODEL=CompVis/stable-diffusion-v1-4
+## HUGGINGFACE_AUDIO_TO_TEXT_MODEL - The model for HuggingFace to use (Default: openai/whisper-large-v2)
+# HUGGINGFACE_AUDIO_TO_TEXT_MODEL=openai/whisper-large-v2
 
 ################################################################################
 ### GITHUB

--- a/.env.template-zh
+++ b/.env.template-zh
@@ -163,8 +163,8 @@ OPENAI_API_KEY=your-openai-api-key
 ## AUDIO_TO_TEXT_PROVIDER - 语音转文本提供商（默认：huggingface）
 # AUDIO_TO_TEXT_PROVIDER=huggingface
 
-## HUGGINGFACE_AUDIO_TO_TEXT_MODEL - HuggingFace 使用的模型（默认：CompVis/stable-diffusion-v1-4）
-# HUGGINGFACE_AUDIO_TO_TEXT_MODEL=CompVis/stable-diffusion-v1-4
+## HUGGINGFACE_AUDIO_TO_TEXT_MODEL - HuggingFace 使用的模型（默认：openai/whisper-large-v2）
+# HUGGINGFACE_AUDIO_TO_TEXT_MODEL=openai/whisper-large-v2
 
 ################################################################################
 ### GITHUB

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -127,7 +127,7 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     image_size: int = 256
     # Audio to text
     audio_to_text_provider: str = "huggingface"
-    huggingface_audio_to_text_model: Optional[str] = None
+    huggingface_audio_to_text_model: str = "openai/whisper-large-v2"
     # Web browsing
     selenium_web_browser: str = "chrome"
     selenium_headless: bool = True

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -24,7 +24,7 @@
 - `GOOGLE_CUSTOM_SEARCH_ENGINE_ID`：[Google 自定义搜索引擎 ID](https://programmablesearchengine.google.com/controlpanel/all)。可选。
 - `HEADLESS_BROWSER`：在 Auto-GPT 使用浏览器时是否启用无头模式。设置为 `False` 可观察浏览器操作。默认值：True
 - `HUGGINGFACE_API_TOKEN`：HuggingFace API，用于图像生成和音频转文本。可选。
-- `HUGGINGFACE_AUDIO_TO_TEXT_MODEL`：HuggingFace 音频转文本模型。默认值：CompVis/stable-diffusion-v1-4
+- `HUGGINGFACE_AUDIO_TO_TEXT_MODEL`：HuggingFace 音频转文本模型。默认值：openai/whisper-large-v2（推荐使用的 OpenAI Whisper Large v2 模型，可在 Hugging Face 获取）
 - `HUGGINGFACE_IMAGE_MODEL`：用于图像生成的 HuggingFace 模型。默认值：CompVis/stable-diffusion-v1-4
 - `IMAGE_PROVIDER`：图像提供方。可选值：`dalle`、`huggingface`、`sdwebui`。默认值：dalle
 - `IMAGE_SIZE`：生成图像的默认尺寸。默认值：256


### PR DESCRIPTION
## Summary
- use `openai/whisper-large-v2` as the default HuggingFace speech-to-text model
- document recommended Whisper model and its source

## Testing
- `pre-commit run --files .env.template .env.template-zh docs/configuration/options.md autogpt/config/config.py` *(fails: mypy unexpected keyword argument; pytest-check missing dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68932be6ea6c832fac0d4d4ce731da66