### PR TITLE
docs: document OPENAI_FUNCTIONS option

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -52,7 +52,7 @@ Demo made by <a href=https://twitter.com/BlakeWerlinger>Blake Werlinger</a>
    The first run creates `auto_gpt_workspace` and other files in your working directory.
    Use `agpt --help` to see all available parameters.
 
-Please see the [documentation][docs] for full setup instructions and configuration options.
+Please see the [documentation][docs] for full setup instructions and [configuration options](docs/configuration/options.md).
 
 [docs]: https://docs.agpt.co/
 
@@ -188,6 +188,7 @@ pytest
 * [🧰 Git Command Guide](docs/commands/git_operations.md)
 * [🧪 Testing Command Guide](docs/commands/testing.md)
 * Configuration
+  * [⚙️ Options](docs/configuration/options.md)
   * [🔍 Web Search](https://docs.agpt.co/configuration/search/)
   * [🧠 Memory](https://docs.agpt.co/configuration/memory/)
   * [🗣️ Voice (TTS)](https://docs.agpt.co/configuration/voice/)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agpt
 首次运行会在工作目录中创建 `auto_gpt_workspace` 等文件。
 使用 `agpt --help` 查看所有可用参数。
 
-完整的设置和配置选项请参阅 [文档][docs]。
+完整的设置和配置选项请参阅 [文档][docs]，环境变量列表见 [配置选项](docs/configuration/options.md)。
 
 [docs]: https://docs.agpt.co/
 
@@ -255,6 +255,7 @@ python scripts/skill_cli.py test my_skill
 * [🧰 Git 命令指南](docs/commands/git_operations.md)
 * [🧪 测试命令指南](docs/commands/testing.md)
 * 配置
+  * [⚙️ 配置选项](docs/configuration/options.md)
   * [🔍 Web 搜索](https://docs.agpt.co/configuration/search/)
   * [🧠 记忆](https://docs.agpt.co/configuration/memory/)
   * [🗣️ 语音（TTS）](https://docs.agpt.co/configuration/voice/)

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -33,6 +33,7 @@
 - `OPENAI_API_KEY`：**必填**——你的 [OpenAI API Key](https://platform.openai.com/account/api-keys)。
 - `OPENAI_API_BASE_URL`：OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
 - `OPENAI_ORGANIZATION`：OpenAI 组织 ID。可选。
+- `OPENAI_FUNCTIONS`：启用 OpenAI Functions 功能（仅限支持函数调用的模型）。可选值：`True`、`False`。默认值：False
 - `PLAIN_OUTPUT`：纯文本输出，禁用旋转指示器。默认值：False
 - `PLUGINS_CONFIG_FILE`：插件配置文件相对于 Auto-GPT 根目录的路径。默认值：plugins_config.yaml
 - `PROMPT_SETTINGS_FILE`：提示词设置文件相对于 Auto-GPT 根目录的位置。默认值：prompt_settings.yaml


### PR DESCRIPTION
## Summary
- document `OPENAI_FUNCTIONS` environment variable and default
- link configuration options doc from READMEs

## Testing
- `pre-commit run --files docs/configuration/options.md README.md README.en.md` *(failed: tests/unit/test_retry_provider_openai.py, tests/unit/test_simple_agent.py, tests/unit/test_web_search.py, tests/unit/test_write_file_ability.py)*
- `pytest tests/unit/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68932bf4fc8c832fa5f55c50521b9e53