### PR TITLE
docs: update memory backend support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -132,7 +132,7 @@ Common flags include:
 - `-w, --workspace-directory PATH` – directory used for the agent's workspace (defaults to `auto_gpt_workspace` inside the working directory).
 - `--ai-settings FILE` – path to a YAML file with AI configuration.
 - `--prompt-settings FILE` – path to a YAML file with prompt settings.
-- `--use-memory BACKEND` – choose a memory backend, e.g. `local`, `redis`.
+- `--use-memory BACKEND` – choose a memory backend, e.g. `json_file`, `chroma`.
 - `--speak` – enable text-to-speech.
 - `--continuous` – run without requiring user authorization.
 - `--gpt3only` – use GPT‑3.5 for all responses.
@@ -142,7 +142,7 @@ Common flags include:
 Example:
 
 ```bash
-agpt --ai-settings ai_settings.yaml --use-memory redis
+agpt --ai-settings ai_settings.yaml --use-memory chroma
 ```
 
 Run `agpt --help` for the full list of options.

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -361,7 +361,7 @@ The library indexes skills in a vector database. The default
 by implementing `VectorDBProvider`:
 
 1. Install and configure your vector DB, e.g. `pip install chromadb` for
-   Chroma or `pip install weaviate-client` for Weaviate.
+   Chroma.
 2. Implement a subclass of `VectorDBProvider` that wraps the database's API.
 3. Create the library with your provider:
 

--- a/docs/configuration/memory.md
+++ b/docs/configuration/memory.md
@@ -4,34 +4,17 @@
 
 ## 设置缓存类型
 
-默认情况下，Auto-GPT 使用 LocalCache（将记忆存储在 JSON 文件中）。
+默认情况下，Auto-GPT 使用 `json_file` 将记忆存储在本地 JSON 文件中。
 
-若要切换到其他后端，可在 `.env` 中将 `MEMORY_BACKEND` 修改为你想要的值：
+当前仅支持以下记忆后端：
 
-* `json_file` 使用本地 JSON 缓存文件
-* `chroma` 使用 [Chroma](https://www.trychroma.com/) 向量数据库
-* `pinecone` 使用在环境变量中配置的 Pinecone.io 账户
-* `redis` 使用你配置的 redis 缓存
-* `milvus` 使用你配置的 milvus 缓存
-* `weaviate` 使用你配置的 weaviate 缓存
+* `json_file` &ndash; 本地 JSON 缓存文件，默认选项
+* `chroma` &ndash; 使用 [Chroma](https://www.trychroma.com/) 向量数据库，[示例配置](#chroma-设置)
+* `no_memory` &ndash; 禁用记忆功能
 
-!!! warning
-    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
-    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
+在 `.env` 中通过设置 `MEMORY_BACKEND` 切换后端。
 
 ## 记忆后端设置
-
-记忆后端链接：
-
-- [Chroma](https://www.trychroma.com/)
-- [Pinecone](https://www.pinecone.io/)
-- [Milvus](https://milvus.io/) &ndash; [自托管](https://milvus.io/docs)，或使用 [Zilliz Cloud](https://zilliz.com/)
-- [Redis](https://redis.io)
-- [Weaviate](https://weaviate.io)
-
-!!! warning
-    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
-    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
 ### Chroma 设置
 
@@ -49,114 +32,16 @@
 
    数据默认保存在工作空间下的 `chroma` 目录。
 
-### Redis 设置
+## 历史记忆后端
 
-!!! caution
-    此设置不应公开访问，缺少安全措施。
-    请避免在没有密码的情况下将 Redis 暴露在互联网，或完全避免暴露！
+以下记忆后端在 v0.4.7 中被移除，目前不受支持。如果未来重新添加，可参考这些链接获取背景信息：
 
-1. 启动 Redis 服务器并确保其监听 6379 端口。
-   你可以使用 [redis.io](https://redis.io) 的本地安装或任何托管服务。
+- [Pinecone](https://www.pinecone.io/)
+- [Milvus](https://milvus.io/) – [自托管](https://milvus.io/docs) 或 [Zilliz Cloud](https://zilliz.com/)
+- [Redis](https://redis.io)
+- [Weaviate](https://weaviate.io)
 
-3. 在 `.env` 中设置以下变量：
-
-    ```shell
-    MEMORY_BACKEND=redis
-    REDIS_HOST=localhost
-    REDIS_PORT=6379
-    REDIS_PASSWORD=<PASSWORD>
-    ```
-
-    将 `<PASSWORD>` 替换为你的密码，省略尖括号。
-
-    可选配置：
-
-    - `WIPE_REDIS_ON_START=False` 在运行之间保留存储在 Redis 中的记忆。
-    - `MEMORY_INDEX=<WHATEVER>` 指定在 Redis 中使用的记忆索引名称，默认值为 `auto-gpt`。
-
-!!! warning
-    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
-    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
-
-### 🌲 Pinecone API Key 设置
-
-Pinecone 允许存储大量向量化记忆，使代理在任何时候只需加载相关记忆。
-
-1. 前往 [pinecone](https://app.pinecone.io/) 并注册账号（如尚未注册）。
-2. 选择 *Starter* 套餐以避免收费。
-3. 在左侧边栏的默认项目下找到你的 API Key 和区域。
-
-在 `.env` 文件中设置：
-
-- `PINECONE_API_KEY`
-- `PINECONE_ENV`（示例：`us-east4-gcp`）
-- `MEMORY_BACKEND=pinecone`
-
-!!! warning
-    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
-    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
-
-### Milvus 设置
-
-[Milvus](https://milvus.io/) 是一个开源、高度可扩展的向量数据库，可存储大量向量化记忆并提供快速的相关搜索。可本地部署或使用 [Zilliz Cloud](https://zilliz.com/) 提供的云服务。
-
-1. 本地部署 Milvus 服务或使用托管的 Zilliz Cloud 数据库：
-    - [本地安装并部署 Milvus](https://milvus.io/docs/install_standalone-operator.md)
-
-    - 设置托管的 Zilliz Cloud 数据库
-        1. 访问 [Zilliz Cloud](https://zilliz.com/) 并注册账号（如尚未注册）。
-        2. 在 *Databases* 选项卡中创建新数据库。
-            - 记下你的用户名和密码
-            - 等待数据库状态变为 RUNNING
-        3. 在所创建数据库的 *Database detail* 选项卡中可以找到公共云端点，例如：`https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443`。
-
-2. 运行 `pip3 install pymilvus` 安装所需客户端库。确保 PyMilvus 版本与你的 Milvus 版本[兼容](https://github.com/milvus-io/pymilvus#compatibility)，以避免问题。参见 [PyMilvus 安装说明](https://github.com/milvus-io/pymilvus#installation)。
-
-3. 更新 `.env`：
-    - `MEMORY_BACKEND=milvus`
-    - 二选一：
-        - `MILVUS_ADDR=host:ip`（本地实例）
-        - `MILVUS_ADDR=https://xxx-xxxx.xxxx.xxxx.zillizcloud.com:443`（Zilliz Cloud）
-    - `MILVUS_USERNAME='username-of-your-milvus-instance'`
-    - `MILVUS_PASSWORD='password-of-your-milvus-instance'`
-    - `MILVUS_SECURE=True` 使用安全连接，仅当你的 Milvus 实例启用了 TLS 时使用。
-        *注意：将 `MILVUS_ADDR` 设置为 `https://` URL 会覆盖此设置。*
-    - `MILVUS_COLLECTION` 更改在 Milvus 中使用的集合名称，默认值为 `autogpt`。
-
-!!! warning
-    Pinecone、Milvus、Redis 和 Weaviate 记忆后端因记忆系统的改动而变得不兼容，已被移除。
-    是否在未来重新添加支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
-
-### Weaviate 设置
-
-[Weaviate](https://weaviate.io/) 是一个开源向量数据库，可存储数据对象和来自机器学习模型的向量嵌入，并能无缝扩展到数十亿个对象。要设置 Weaviate 数据库，请查看其[快速入门教程](https://weaviate.io/developers/weaviate/quickstart)。
-
-虽然仍处于实验阶段，但支持使用 [嵌入式 Weaviate](https://weaviate.io/developers/weaviate/installation/embedded)，可让 Auto-GPT 进程自行启动一个 Weaviate 实例。要启用它，将 `USE_WEAVIATE_EMBEDDED` 设置为 `True`，并确保执行 `pip install "weaviate-client>=3.15.4"`。
-
-#### 安装 Weaviate 客户端
-
-在使用前安装 Weaviate 客户端。
-
-```shell
-$ pip install weaviate-client
-```
-
-#### 设置环境变量
-
-在 `.env` 文件中设置以下内容：
-
-```ini
-MEMORY_BACKEND=weaviate
-WEAVIATE_HOST="127.0.0.1" # 运行中 Weaviate 实例的 IP 或域名
-WEAVIATE_PORT="8080"
-WEAVIATE_PROTOCOL="http"
-WEAVIATE_USERNAME="your username"
-WEAVIATE_PASSWORD="your password"
-WEAVIATE_API_KEY="your weaviate API key if you have one"
-WEAVIATE_EMBEDDED_PATH="/home/me/.local/share/weaviate" # 可选，运行嵌入式实例时数据持久化的位置
-USE_WEAVIATE_EMBEDDED=False # 设为 True 以运行嵌入式 Weaviate
-MEMORY_INDEX="Autogpt" # 为应用创建的索引名称
-```
+是否恢复支持仍在讨论中，欢迎在 https://github.com/Significant-Gravitas/Auto-GPT/discussions/4280 参与讨论。
 
 ## 长期记忆
 
@@ -215,11 +100,6 @@ DIR 路径是相对于 `auto_gpt_workspace` 目录的，因此 `python data_inge
 - 增大 `max_length` 能在每个块中提供更多上下文，减少块数量并节省 OpenAI API 请求，但可能使用更多提示词 Token，并降低 AI 可用的总上下文。
 
 记忆预置是一种通过预先摄取相关数据来提升 AI 准确度的技术。数据会被拆分成若干块并加入记忆，AI 可以快速访问，从而生成更准确的响应。它适用于大数据集或需要快速访问特定信息的场景，例如在运行 Auto-GPT 之前摄取 API 或 GitHub 文档。
-
-!!! attention
-    如果使用 Redis 作为记忆，请确保运行 Auto-GPT 时设置 `WIPE_REDIS_ON_START=False`
-
-    对于其他记忆后端，我们目前在启动 Auto-GPT 时会强制清空记忆。要在这些后端摄取数据，你可以在 Auto-GPT 运行期间随时调用 `data_ingestion.py` 脚本。
 
 记忆在摄取后会立即对 AI 可用，即使在 Auto-GPT 运行过程中摄取也是如此。
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -37,9 +37,6 @@
 - `PLAIN_OUTPUT`：纯文本输出，禁用旋转指示器。默认值：False
 - `PLUGINS_CONFIG_FILE`：插件配置文件相对于 Auto-GPT 根目录的路径。默认值：plugins_config.yaml
 - `PROMPT_SETTINGS_FILE`：提示词设置文件相对于 Auto-GPT 根目录的位置。默认值：prompt_settings.yaml
-- `REDIS_HOST`：Redis 主机。默认值：localhost
-- `REDIS_PASSWORD`：Redis 密码。可选。默认值为空
-- `REDIS_PORT`：Redis 端口。默认值：6379
 - `RESTRICT_TO_WORKSPACE`：是否将文件读写限制在工作空间目录内。默认值：True
 - `SD_WEBUI_AUTH`：Stable Diffusion Web UI 的 `username:password`。可选。
 - `SD_WEBUI_URL`：Stable Diffusion Web UI 的 URL。默认值：http://localhost:7860
@@ -54,7 +51,15 @@
 - `USE_AZURE`：是否使用 Azure 的 LLM。默认值：False
 - `USE_LIBRARIAN`：是否使用 LibrarianAgent 进行技能推荐。默认值：True
 - `USE_WEB_BROWSER`：使用的网页浏览器，选项有 `chrome`、`firefox`、`safari`、`edge`。默认值：chrome
-- `WIPE_REDIS_ON_START`：启动时是否清空数据/索引。默认值：True
 - `SELF_DEVELOP`：启用后台自我开发循环。默认值：False
 - `SELF_DEVELOP_INTERVAL`：启用自我开发时仓库扫描的间隔秒数。默认值：300
+
+### 已弃用的环境变量
+
+以下变量用于已移除的记忆后端（如 Redis），目前无效，仅保留作历史参考：
+
+- `REDIS_HOST`
+- `REDIS_PASSWORD`
+- `REDIS_PORT`
+- `WIPE_REDIS_ON_START`
 


### PR DESCRIPTION
## Summary
- clarify that only json_file, chroma and no_memory backends are supported
- remove obsolete setup steps for Pinecone, Milvus, Redis and Weaviate
- document deprecated Redis environment variables
- update examples to use chroma and clean up vector DB docs

## Testing
- `pre-commit run --files docs/configuration/memory.md docs/configuration/options.md README.en.md docs/architecture/agents.md` *(fails: ModuleNotFoundError, pytest errors)*

------
https://chatgpt.com/codex/tasks/task_e_689342c04674832f8becd062f4c08e79