### PR TITLE
docs: remove stable branch warnings

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -9,14 +9,6 @@
 
 <hr/>
 
-### 🔴 USE `stable` not `master` 🔴
-
-**Download the latest `stable` release from here: https://github.com/Significant-Gravitas/Auto-GPT/releases/latest.**
-The `master` branch is under heavy development and may often be in a **broken** state.
-
-<hr/>
-
-
 Auto-GPT is an experimental open-source application showcasing the capabilities of the GPT-4 language model. This program, driven by GPT-4, chains together LLM "thoughts", to autonomously achieve whatever goal you set. As one of the first examples of GPT-4 running fully autonomously, Auto-GPT pushes the boundaries of what is possible with AI.
 
 <h2 align="center"> Demo April 16th 2023 </h2>
@@ -63,7 +55,7 @@ Auto-GPT requires **Python 3.10 or later**.
 Clone the repository and enter the project directory:
 
 ```bash
-git clone -b stable https://github.com/Significant-Gravitas/Auto-GPT.git
+git clone https://github.com/Significant-Gravitas/Auto-GPT.git
 cd Auto-GPT
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@
 
 ---
 
-### 🔴 请使用 `stable` 而非 `master` 🔴
-
-**最新稳定版下载地址：https://github.com/Significant-Gravitas/Auto-GPT/releases/latest**
-`master` 分支处于快速开发中，可能经常处于 **不可用** 状态。
-
----
-
 Auto-GPT 是一个实验性的开源应用，用于展示 GPT-4 语言模型的能力。该程序由 GPT-4 驱动，将 LLM 的“思考”串联起来，自主完成你设定的任何目标。作为 GPT-4 完全自主运行的首批示例之一，Auto-GPT 正在推动 AI 的边界。
 
 ## 🚀 功能
@@ -59,7 +52,7 @@ Auto-GPT 需要 **Python 3.10 或更高版本**。
 克隆仓库并进入项目目录：
 
 ```bash
-git clone -b stable https://github.com/Significant-Gravitas/Auto-GPT.git
+git clone https://github.com/Significant-Gravitas/Auto-GPT.git
 cd Auto-GPT
 ```
 


### PR DESCRIPTION
## Summary
- remove outdated warning advising use of `stable` instead of `master`
- simplify clone instructions to default branch in README files

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'vcr')*


------
https://chatgpt.com/codex/tasks/task_e_68937002fc88832f94c4a37762bc32fa