### PR TITLE
docs: update setup instructions

### DIFF
--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -42,7 +42,7 @@ Get your OpenAI API key from: [https://platform.openai.com/account/api-keys](htt
 1. Clone the repository
 
     ```shell
-    git clone -b stable https://github.com/Significant-Gravitas/Auto-GPT.git
+    git clone https://github.com/Significant-Gravitas/Auto-GPT.git
     ```
 
 2. Navigate to the directory where you downloaded the repository
@@ -53,7 +53,7 @@ Get your OpenAI API key from: [https://platform.openai.com/account/api-keys](htt
 
 ### Set up from release archive
 
-1. Download `Source code (zip)` from the [latest stable release](https://github.com/Significant-Gravitas/Auto-GPT/releases/latest)
+1. Download `Source code (zip)` from the [latest release](https://github.com/Significant-Gravitas/Auto-GPT/releases/latest)
 2. Extract the zip-file into a folder
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -33,7 +33,7 @@ Auto-GPT 在本地运行，你需要：
 1. 克隆仓库
 
     ```shell
-    git clone -b stable https://github.com/Significant-Gravitas/Auto-GPT.git
+    git clone https://github.com/Significant-Gravitas/Auto-GPT.git
     ```
 
 2. 进入仓库目录
@@ -44,7 +44,7 @@ Auto-GPT 在本地运行，你需要：
 
 ### 使用发布包安装
 
-1. 从[最新稳定版本](https://github.com/Significant-Gravitas/Auto-GPT/releases/latest)下载 `Source code (zip)`。
+1. 从[最新发布版本](https://github.com/Significant-Gravitas/Auto-GPT/releases/latest)下载 `Source code (zip)`。
 2. 将压缩包解压到文件夹。
 
 ### 配置


### PR DESCRIPTION
## Summary
- direct users to clone repository without specifying stable branch
- reference the latest release rather than the latest stable release

## Testing
- `pre-commit run --files docs/setup.md docs/setup.en.md` (fails: ModuleNotFoundError: No module named 'openai.error')
- `SKIP=pytest-check pre-commit run --files docs/setup.md docs/setup.en.md`


------
https://chatgpt.com/codex/tasks/task_e_6893700c5714832f9c109c471539acad