### PR TITLE
Use attribute access for OpenAI embedding results

### DIFF
--- a/autogpt/memory/vector/utils.py
+++ b/autogpt/memory/vector/utils.py
@@ -64,10 +64,10 @@ def get_embedding(
     ).data
 
     if not multiple:
-        return embeddings[0]["embedding"]
+        return embeddings[0].embedding
 
-    embeddings = sorted(embeddings, key=lambda x: x["index"])
-    return [d["embedding"] for d in embeddings]
+    embeddings = sorted(embeddings, key=lambda x: x.index)
+    return [d.embedding for d in embeddings]
 
 
 def _get_embedding_with_plugin(text: str, config: Config) -> Embedding:


### PR DESCRIPTION
## Summary
- Update embedding retrieval to use object attributes from OpenAI responses

## Testing
- `pytest tests/unit/test_librarian_agent.py tests/unit/test_archaeologist_agent.py tests/unit/test_skill_library.py tests/unit/test_skill_repository.py -q`
- `python - <<'PY'
import importlib.util
from types import SimpleNamespace
import autogpt.llm.providers.openai as iopenai
spec = importlib.util.spec_from_file_location('utils', 'autogpt/memory/vector/utils.py')
utils = importlib.util.module_from_spec(spec)
spec.loader.exec_module(utils)
get_embedding = utils.get_embedding
class DummyOpenAI:
    @staticmethod
    def create_embedding(input, **kwargs):
        from types import SimpleNamespace
        if isinstance(input, str):
            data=[SimpleNamespace(embedding=[1.0,2.0], index=0)]
        else:
            data=[SimpleNamespace(embedding=[3.0,4.0], index=1), SimpleNamespace(embedding=[1.0,2.0], index=0)]
        return SimpleNamespace(data=data)

iopenai.create_embedding = DummyOpenAI.create_embedding
config = SimpleNamespace(embedding_model='test-model', plugins=[], use_azure=False,
                         get_openai_credentials=lambda model: {})
print('single:', get_embedding('hello', config))
print('multi:', get_embedding(['foo','bar'], config))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68949be12550832f804f717ca7315b99