### PR TITLE
feat: add plugin library metadata

### DIFF
--- a/autogpt/plugins/loader.py
+++ b/autogpt/plugins/loader.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from autogpt.plugins.models import (
+    PluginMeta,
+    PluginMetaValidationError,
+)
+
+
+def load_plugin_meta(path: str | Path) -> PluginMeta:
+    """Load and validate plugin metadata from ``path``.
+
+    Args:
+        path: Path to a JSON metadata file.
+
+    Returns:
+        Parsed :class:`PluginMeta` instance.
+
+    Raises:
+        PluginMetaValidationError: If the metadata is missing required
+            fields, has invalid values, or references a non-existent
+            ``local_source_path``.
+    """
+
+    metadata_path = Path(path)
+    try:
+        raw = metadata_path.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
+        raise PluginMetaValidationError(f"Metadata file '{path}' not found") from e
+
+    try:
+        data: dict[str, Any] = json.loads(raw)
+        meta = PluginMeta.parse_obj(data)
+    except (json.JSONDecodeError, ValidationError) as e:
+        raise PluginMetaValidationError(f"Invalid plugin metadata: {e}") from e
+
+    source_path = Path(meta.underlying_library.local_source_path).expanduser()
+    if not source_path.exists():
+        raise PluginMetaValidationError(
+            f"local_source_path '{meta.underlying_library.local_source_path}' does not exist"
+        )
+
+    return meta

--- a/autogpt/plugins/models.py
+++ b/autogpt/plugins/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from enum import Enum
+from pydantic import BaseModel, HttpUrl
+
+
+class SourceCodeAccessPolicy(str, Enum):
+    """Policy describing how plugin source code may be accessed."""
+
+    ALLOWED_FOR_READ_ONLY = "ALLOWED_FOR_READ_ONLY"
+    RESTRICTED = "RESTRICTED"
+
+
+class UnderlyingLibrary(BaseModel):
+    """Information about the library a plugin depends on."""
+
+    name: str
+    version: str
+    repo_url: HttpUrl
+    local_source_path: str
+
+
+class PluginMeta(BaseModel):
+    """Metadata describing a plugin stub or implementation."""
+
+    name: str
+    description: str
+    instructions: str
+    underlying_library: UnderlyingLibrary
+    source_code_access_policy: SourceCodeAccessPolicy
+
+
+class PluginMetaValidationError(ValueError):
+    """Raised when plugin metadata is invalid."""
+
+    pass

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,9 +30,21 @@ plugin_b:
    ```json
    {
      "name": "sample",
-     "description": "sample plugin"
+     "description": "sample plugin",
+     "instructions": "describe the behaviour",
+     "underlying_library": {
+       "name": "some-lib",
+       "version": "1.0.0",
+       "repo_url": "https://example.com/some-lib",
+       "local_source_path": "relative/path/to/lib"
+     },
+     "source_code_access_policy": "ALLOWED_FOR_READ_ONLY"
    }
    ```
+
+   其中 `source_code_access_policy` 的可选值为 `ALLOWED_FOR_READ_ONLY` 或
+   `RESTRICTED`；`underlying_library` 字段需包含库名称、版本、仓库地址
+   以及本地源码路径。
 
 3. 运行以下命令将规范转换为 Python 模块：
 

--- a/plugins/stubs/echo.spec.json
+++ b/plugins/stubs/echo.spec.json
@@ -1,5 +1,12 @@
 {
   "name": "echo",
   "description": "A simple plugin that echoes input",
-  "instructions": "Create a function echo(text: str) -> str that returns text"
+  "instructions": "Create a function echo(text: str) -> str that returns text",
+  "underlying_library": {
+    "name": "python",
+    "version": "3.11",
+    "repo_url": "https://github.com/python/cpython",
+    "local_source_path": "plugins/stubs/echo.spec.json"
+  },
+  "source_code_access_policy": "ALLOWED_FOR_READ_ONLY"
 }

--- a/scripts/generate_plugins.py
+++ b/scripts/generate_plugins.py
@@ -8,11 +8,12 @@ a basic stub implementation.
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
+import json
 
 from black import FileMode, format_str
+from autogpt.plugins.loader import load_plugin_meta
 
 try:
     import openai
@@ -54,10 +55,9 @@ def generate_plugins(base_dir: Path | str = Path(__file__).resolve().parents[1])
     out_dir = base / "plugins"
     out_dir.mkdir(exist_ok=True)
     for spec_file in stubs_dir.glob("*.spec.json"):
-        with open(spec_file, "r", encoding="utf-8") as f:
-            spec = json.load(f)
-        name = spec.get("name") or spec_file.stem
-        code = llm_generate(spec)
+        spec = load_plugin_meta(spec_file)
+        name = spec.name or spec_file.stem
+        code = llm_generate(spec.dict())
         formatted = format_str(AUTO_HEADER + "\n" + code, mode=FileMode())
         target = out_dir / f"{name}.py"
         with open(target, "w", encoding="utf-8") as f:

--- a/tests/unit/test_plugin_loader.py
+++ b/tests/unit/test_plugin_loader.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from autogpt.plugins.loader import load_plugin_meta, PluginMetaValidationError
+
+
+def test_load_plugin_meta_success(tmp_path: Path) -> None:
+    src_file = tmp_path / "dummy.py"
+    src_file.write_text("print('ok')")
+    spec = {
+        "name": "demo",
+        "description": "demo plugin",
+        "instructions": "do things",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": str(src_file),
+        },
+        "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
+    }
+    spec_file = tmp_path / "plugin.json"
+    spec_file.write_text(json.dumps(spec))
+    meta = load_plugin_meta(spec_file)
+    assert meta.name == "demo"
+    assert meta.underlying_library.local_source_path == str(src_file)
+
+
+def test_load_plugin_meta_missing_field(tmp_path: Path) -> None:
+    spec = {
+        "name": "demo",
+        "description": "demo plugin",
+        "instructions": "do things",
+        "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
+    }
+    spec_file = tmp_path / "plugin.json"
+    spec_file.write_text(json.dumps(spec))
+    with pytest.raises(PluginMetaValidationError):
+        load_plugin_meta(spec_file)
+
+
+def test_load_plugin_meta_invalid_policy(tmp_path: Path) -> None:
+    src = tmp_path / "src.py"
+    src.write_text("# test")
+    spec = {
+        "name": "demo",
+        "description": "demo plugin",
+        "instructions": "do things",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": str(src),
+        },
+        "source_code_access_policy": "UNKNOWN",
+    }
+    spec_file = tmp_path / "plugin.json"
+    spec_file.write_text(json.dumps(spec))
+    with pytest.raises(PluginMetaValidationError):
+        load_plugin_meta(spec_file)


### PR DESCRIPTION
## Summary
- support tracking plugin underlying libraries and source-code access policy
- validate plugin metadata and ensure local source paths exist
- document new fields and test plugin metadata loading errors

## Testing
- `pytest tests/unit/test_plugin_loader.py --noconftest -q`
- `pytest tests/unit/test_simple_plugin_service.py --noconftest -q`


------
https://chatgpt.com/codex/tasks/task_e_68949f82ef5c832f9d33f624fb9600b5