### PR TITLE
docs: add local model server setup

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -44,6 +44,8 @@ Demo made by <a href=https://twitter.com/BlakeWerlinger>Blake Werlinger</a>
    The first run creates `auto_gpt_workspace` and other files in your working directory.
    Use `agpt --help` to see all available parameters.
 
+For using a locally hosted or proxy model, see [Using a local model server](docs/setup.en.md#using-a-local-model-server).
+
 Please see the [documentation][docs] for full setup instructions and [configuration options](docs/configuration/options.md).
 
 [docs]: https://docs.agpt.co/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ agpt
 首次运行会在工作目录中创建 `auto_gpt_workspace` 等文件。
 使用 `agpt --help` 查看所有可用参数。
 
+如果要使用本地托管或代理模型，请参阅 [使用本地模型服务器](docs/setup.md#使用本地模型服务器)。
+
 完整的设置和配置选项请参阅 [文档][docs]，环境变量列表见 [配置选项](docs/configuration/options.md)。
 
 [docs]: https://docs.agpt.co/

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -32,6 +32,8 @@
 - `MEMORY_INDEX`：在记忆后端中用于作用域、命名或索引的值。默认值：auto-gpt
 - `OPENAI_API_KEY`：**必填**——你的 [OpenAI API Key](https://platform.openai.com/account/api-keys)。
 - `OPENAI_API_BASE_URL`：OpenAI API 的自定义 URL，用于连接自定义后端或本地代理。留空将使用官方端点。
+  例如将其设置为 `http://localhost:8000/v1` 可指向本地或代理服务器，
+  以使用自托管模型。
 - `OPENAI_ORGANIZATION`：OpenAI 组织 ID。可选。
 - `OPENAI_FUNCTIONS`：启用 OpenAI Functions 功能（仅限支持函数调用的模型）。可选值：`True`、`False`。默认值：False
 - `PLAIN_OUTPUT`：纯文本输出，禁用旋转指示器。默认值：False

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -28,6 +28,14 @@ Get your OpenAI API key from: [https://platform.openai.com/account/api-keys](htt
 ![For OpenAI API key to work, set up paid account at OpenAI API > Billing](./imgs/openai-api-key-billing-paid-account.png)
 
 
+### Using a local model server
+
+To point Auto-GPT to a locally served model, set `OPENAI_API_BASE_URL` to your
+server's endpoint, e.g. `http://localhost:8000/v1`. Update `SMART_LLM`,
+`FAST_LLM`, and `EMBEDDING_MODEL` to match the model names your server
+provides. If the server does not require authentication, any placeholder value
+for `OPENAI_API_KEY` will suffice.
+
 ## Setting up Auto-GPT
 
 ### Set up with Git

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,6 +20,13 @@ Auto-GPT 在本地运行，你需要：
 
 ![为使 OpenAI API key 正常工作，请在 OpenAI API > Billing 中设置付费账号](./imgs/openai-api-key-billing-paid-account.png)
 
+### 使用本地模型服务器
+
+要使用本地提供的模型，将 `OPENAI_API_BASE_URL` 设置为服务器地址，例
+如 `http://localhost:8000/v1`。同时把 `SMART_LLM`、`FAST_LLM` 和
+`EMBEDDING_MODEL` 调整为该服务器提供的模型名称。若服务端无需验证，
+`OPENAI_API_KEY` 可使用任意占位值。
+
 ## 设置 Auto-GPT
 
 ### 使用 Git 安装


### PR DESCRIPTION
## Summary
- document configuring Auto-GPT to use a local model server
- explain OPENAI_API_BASE_URL and model name overrides in config reference
- link README setup to local model server docs

## Testing
- `pre-commit run --files README.en.md README.md docs/configuration/options.md docs/setup.en.md docs/setup.md` *(fails: ModuleNotFoundError: No module named 'distro')*


------
https://chatgpt.com/codex/tasks/task_e_6894a42409e4832f84b43a7a3cb95955