### PR TITLE
Add plugin source code path access control

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Tuple
 
 from autogpt.config import Config
 from autogpt.logs import logger
+from autogpt.plugins.loader import PluginMetaValidationError, load_plugin_meta
+from autogpt.plugins.models import SourceCodeAccessPolicy
 from autogpt.telemetry import telemetry
 
 from .library import SkillLibrary, SkillMetadata
@@ -40,11 +42,11 @@ class LibrarianAgent:
 
         cache_key = (query, top_k)
         if cache_key in self._search_cache:
-            results = self._search_cache[cache_key]
+            cached_results = self._search_cache[cache_key]
             telemetry.increment(
-                "find_skill.success" if results else "find_skill.failure"
+                "find_skill.success" if cached_results else "find_skill.failure"
             )
-            return results
+            return cached_results
 
         skills = self.skill_library.search(query, top_k=top_k)
         top_metadata = asdict(skills[0].metadata) if skills else None
@@ -136,9 +138,43 @@ class LibrarianAgent:
             )
             return True
         except Exception as err:
-            logger.error(
-                f"Failed to register skill {metadata.skill_name}: {err}"
-            )
+            logger.error(f"Failed to register skill {metadata.skill_name}: {err}")
             raise RuntimeError(
                 f"Failed to register skill {metadata.skill_name}"
             ) from err
+
+    # ------------------------------------------------------------------
+    def get_source_code_path(self, plugin_name: str) -> str | None:
+        """Return the local source path for a plugin if access is allowed.
+
+        Parameters
+        ----------
+        plugin_name: str
+            Name of the plugin whose source path is requested.
+        """
+
+        plugins_dir = Path(self.skill_library.config.plugins_dir)
+        for meta_file in plugins_dir.rglob("*.json"):
+            try:
+                meta = load_plugin_meta(meta_file)
+            except PluginMetaValidationError:
+                logger.warn("Skipping invalid plugin metadata: %s", meta_file)
+                continue
+
+            if meta.name != plugin_name:
+                continue
+
+            policy = meta.source_code_access_policy
+            if policy == SourceCodeAccessPolicy.ALLOWED_FOR_READ_ONLY:
+                return meta.underlying_library.local_source_path
+
+            logger.warn(
+                "Access to source code for plugin '%s' denied by policy '%s'",
+                plugin_name,
+                policy,
+            )
+            telemetry.increment("get_source_code_path.denied")
+            return None
+
+        logger.warn("Plugin '%s' not found", plugin_name)
+        return None

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
-from pathlib import Path
-
 import logging
+from pathlib import Path
 
 from autogpt.config import Config
 from autogpt.skills import LibrarianAgent
 
-
 logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Interact with the librarian agent")
@@ -25,6 +24,11 @@ def main() -> None:
     add_p = sub.add_parser("add", help="Add a new skill")
     add_p.add_argument("metadata", help="Path to JSON metadata file")
     add_p.add_argument("code", help="Path to Python file containing the skill")
+
+    src_p = sub.add_parser(
+        "source-path", help="Print the source code path for a plugin"
+    )
+    src_p.add_argument("plugin_name", help="Name of the plugin")
 
     args = parser.parse_args()
     agent = LibrarianAgent(Config())
@@ -46,6 +50,12 @@ def main() -> None:
                 print("Failed to add skill")
         except Exception:
             logger.exception("Failed to add skill")
+    elif args.command == "source-path":
+        path = agent.get_source_code_path(args.plugin_name)
+        if path:
+            print(path)
+        else:
+            print("Access denied or plugin not found")
     else:
         parser.print_help()
 

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import asdict
 from pathlib import Path
 from types import SimpleNamespace
@@ -36,6 +37,28 @@ def _metadata() -> dict:
         "author_agent": "tester",
         "creation_timestamp": "2024-01-01T00:00:00Z",
     }
+
+
+def _create_plugin_spec(tmp_path: Path, name: str, policy: str) -> tuple[Path, Path]:
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    source_file = plugin_dir / f"{name}.py"
+    source_file.write_text("print('hi')\n")
+
+    meta = {
+        "name": name,
+        "description": "Test plugin",
+        "instructions": "",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": str(source_file),
+        },
+        "source_code_access_policy": policy,
+    }
+    (plugin_dir / f"{name}.json").write_text(json.dumps(meta))
+    return plugin_dir, source_file
 
 
 def test_add_and_find_skill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -175,3 +198,35 @@ def test_find_skill_records_telemetry(
     counts = telemetry.get_counts()
     assert counts.get("find_skill.success", 0) == 1
     assert counts.get("find_skill.failure", 0) == 1
+
+
+def test_get_source_code_path_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin_dir, source_file = _create_plugin_spec(
+        tmp_path, "allowed", "ALLOWED_FOR_READ_ONLY"
+    )
+    agent = _setup_agent(tmp_path, monkeypatch)
+    agent.skill_library.config.plugins_dir = str(plugin_dir)
+
+    telemetry.reset()
+    path = agent.get_source_code_path("allowed")
+    assert path == str(source_file)
+    assert telemetry.get_counts().get("get_source_code_path.denied", 0) == 0
+
+
+def test_get_source_code_path_restricted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    plugin_dir, _ = _create_plugin_spec(tmp_path, "restricted", "RESTRICTED")
+    agent = _setup_agent(tmp_path, monkeypatch)
+    agent.skill_library.config.plugins_dir = str(plugin_dir)
+
+    telemetry.reset()
+    with caplog.at_level("WARNING"):
+        path = agent.get_source_code_path("restricted")
+    assert path is None
+    assert any(
+        "Access to source code for plugin" in rec.message for rec in caplog.records
+    )
+    assert telemetry.get_counts().get("get_source_code_path.denied", 0) == 1


### PR DESCRIPTION
## Summary
- add librarian method to fetch plugin source path and honor access policy
- expose source-path lookup via librarian CLI
- cover allowed and restricted plugin source lookup in unit tests

## Testing
- `pytest tests/unit/test_librarian_agent.py::test_get_source_code_path_allowed tests/unit/test_librarian_agent.py::test_get_source_code_path_restricted -q`
- `SKIP=pytest-check,autoflake pre-commit run --files autogpt/skills/librarian.py scripts/librarian_cli.py tests/unit/test_librarian_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6894a2002d88832fa2e3971d93d5165e