### PR TITLE
feat: extend archaeologist diagnostics

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -151,12 +151,17 @@ class Archaeologist:
         query = self._generate_query(query_payload)
 
         skills: list[dict[str, Any]] = []
+        plugins: list[str] = []
         top_k = 3
         if self.librarian:
             try:
                 skills = self.librarian.find_skill(query, top_k=top_k)
             except Exception as err:  # noqa: BLE001
                 logger.error(f"Error searching for skill: {err}")
+            try:
+                plugins = self.librarian.find_plugin(query)
+            except Exception as err:  # noqa: BLE001
+                logger.error(f"Error searching for plugin: {err}")
         if skills:
             if any("score" in s for s in skills):
                 skill = max(skills, key=lambda s: s.get("score", float("-inf")))
@@ -167,29 +172,55 @@ class Archaeologist:
             param_list = ", ".join(params.keys()) if params else "no parameters"
             desc = skill.get("description")
             if desc:
-                skill_rec = _(
-                    "Issue can be solved by invoking {call_name} ({desc}) with parameters: {param_list}."
+                action_rec = _(
+                    "Call existing skill {call_name} ({desc}) with parameters: {param_list}."
                 ).format(call_name=call_name, desc=desc, param_list=param_list)
             else:
-                skill_rec = _(
-                    "Issue can be solved by invoking {call_name} with parameters: {param_list}."
+                action_rec = _(
+                    "Call existing skill {call_name} with parameters: {param_list}."
                 ).format(call_name=call_name, param_list=param_list)
             details["recommended_skill"] = {
                 "name": skill["skill_name"],
                 "version": skill["version"],
                 "parameters": params,
             }
+        elif plugins and self.evaluate_plugin_combo(plugins):
+            combo = " -> ".join(plugins)
+            action_rec = _("Combine {combo}.").format(combo=combo)
+            details["recommended_skill"] = None
+            details["plugin_combo"] = plugins
         else:
-            skill_rec = _("New skill development recommended.")
+            source_paths: dict[str, str] = {}
+            if self.librarian:
+                for plugin in plugins:
+                    try:
+                        path = self.librarian.get_source_code_path(plugin)
+                    except Exception as err:  # noqa: BLE001
+                        logger.error(
+                            f"Error retrieving source path for plugin '{plugin}': {err}"
+                        )
+                        path = None
+                    if path:
+                        source_paths[plugin] = path
+            if source_paths:
+                path_list = ", ".join(f"{p}: {pth}" for p, pth in source_paths.items())
+                action_rec = _(
+                    "Enter source-code borrowing mode. Sources: {paths}."
+                ).format(paths=path_list)
+                details["source_code_paths"] = source_paths
+            else:
+                action_rec = _("New skill development recommended.")
+                details["source_code_paths"] = {}
             details["recommended_skill"] = None
 
         base_rec = self._recommendations(analysis)
         recs = []
         if base_rec and base_rec != "No recommendations.":
             recs.append(base_rec)
-        recs.append(skill_rec)
+        recs.append(action_rec)
         recommendations = " ".join(recs)
         details["skill_search"] = skills[:top_k]
+        details["plugin_search"] = plugins
 
         event = DiagnosisComplete(
             summary=summary,
@@ -361,6 +392,15 @@ class Archaeologist:
                 analyze_dependency(dep, source_path, new_version=new_version)
             )
         return analyses
+
+    def evaluate_plugin_combo(self, plugin_ids: list[str]) -> bool:
+        """Assess whether combining ``plugin_ids`` solves the issue simply.
+
+        This stub always returns ``False``; tests may patch it with heuristic or
+        LLM-backed logic.
+        """
+
+        return False
 
     def _recommendations(self, analysis: dict[str, Any]) -> str:
         """Create a simple recommendation string from analysis data."""

--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -84,6 +84,17 @@ class LibrarianAgent:
         return results
 
     # ------------------------------------------------------------------
+    def find_plugin(self, query: str) -> List[str]:
+        """Search for plugins related to ``query``.
+
+        This is a lightweight placeholder that integrations may override with
+        real plugin discovery. It returns an empty list by default.
+        """
+
+        telemetry.increment("find_plugin.failure")
+        return []
+
+    # ------------------------------------------------------------------
     def add_skill(self, skill_metadata: dict, skill_code_path: str) -> bool:
         """Add a new skill to the library.
 

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -73,20 +73,29 @@ Expected `ISSUE_DETECTED` payload fields:
 1. **Extract issue** – Parse event payloads to pull out metadata like file,
    line, commit hash and dependency information.
 2. **Query librarian** – Build a search string from the issue details and call
-   `LibrarianAgent.find_skill` to look for existing remediation skills.
-3. **Branch on results** – If a relevant skill is found, recommend invoking it;
-    otherwise recommend developing a new skill or apply manual fixes.
+   `LibrarianAgent.find_skill` followed by `LibrarianAgent.find_plugin` to
+   surface reusable skills or related plugins.
+3. **Branch on results** – The archaeologist chooses one of three paths:
+   - *Call existing skill* when a suitable skill is found.
+   - *Combine Plugin_A → Plugin_B* if `find_plugin` returns candidates and
+     `evaluate_plugin_combo` deems a simple composition viable.
+   - *Enter source-code borrowing mode* when combos are insufficient; it then
+     asks the librarian for each candidate's source via
+     `get_source_code_path` and proceeds only with accessible paths.
 4. **Publish `DIAGNOSIS_COMPLETE`** – Emit diagnostics summarising the issue
-   and the skill search outcome for downstream agents.
+   and the chosen remediation strategy for downstream agents.
 
 ### Librarian integration and event payload
 
-`LibrarianAgent.find_skill` enables the archaeologist to reuse prior work. The
-agent includes the raw search results in the `skill_search` field and the top
-match in `recommended_skill` within the `DIAGNOSIS_COMPLETE` event's
-`details`. When a match is found the event's `actionable_recommendations`
-directs consumers to invoke the suggested skill; otherwise it signals that new
-skill development is recommended.
+`LibrarianAgent.find_skill` enables the archaeologist to reuse prior work while
+`find_plugin` and `get_source_code_path` provide guidance when no skill
+matches. The agent includes the raw search results in `skill_search` and
+`plugin_search` and records the top match in `recommended_skill`, the chosen
+plugin chain in `plugin_combo`, or any retrieved source locations in
+`source_code_paths`. When a match is found the event's
+`actionable_recommendations` directs consumers to invoke the suggested skill,
+combine plugins or borrow source code; otherwise it signals that new skill
+development is recommended.
 
 Repeated calls to `find_skill` are cached by the librarian so common queries do
 not repeatedly hit the underlying skill library. This keeps the interface

--- a/tests/unit/test_archaeologist_agent.py
+++ b/tests/unit/test_archaeologist_agent.py
@@ -319,6 +319,108 @@ def test_on_issue_detected_recommends_new_skill_when_none_found(
 
 
 @pytest.mark.parametrize("event_type", [ISSUE_DETECTED])
+def test_on_issue_detected_recommends_plugin_combo(event_type: str) -> None:
+    message_queue = MessageQueue()
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    with (
+        patch.object(arch_module, "LibrarianAgent") as MockLib,
+        patch.object(arch_module.Archaeologist, "evaluate_plugin_combo", return_value=True),
+    ):
+        MockLib.return_value.find_skill.return_value = []
+        MockLib.return_value.find_plugin.return_value = ["PluginA", "PluginB"]
+        Archaeologist(message_queue)
+
+        payload = {
+            "plugin": "test_plugin",
+            "issue_type": "bug",
+            "error_log": "runtime error",
+            "description": "runtime error",
+        }
+        message_queue.publish(
+            EventMessage(event_type=event_type, payload=payload, source_agent="tester")
+        )
+
+    assert len(received) == 1
+    diag = received[0]
+    assert "Combine PluginA -> PluginB" in diag.actionable_recommendations
+    assert diag.details is not None
+    details = cast(dict[str, Any], diag.details)
+    assert details["plugin_combo"] == ["PluginA", "PluginB"]
+    assert details["recommended_skill"] is None
+
+
+@pytest.mark.parametrize("event_type", [ISSUE_DETECTED])
+def test_on_issue_detected_source_code_borrowing_allowed(event_type: str) -> None:
+    message_queue = MessageQueue()
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    with (
+        patch.object(arch_module, "LibrarianAgent") as MockLib,
+        patch.object(arch_module.Archaeologist, "evaluate_plugin_combo", return_value=False),
+    ):
+        MockLib.return_value.find_skill.return_value = []
+        MockLib.return_value.find_plugin.return_value = ["PluginC"]
+        MockLib.return_value.get_source_code_path.return_value = "/src/path"
+        Archaeologist(message_queue)
+
+        payload = {
+            "plugin": "test_plugin",
+            "issue_type": "bug",
+            "error_log": "runtime error",
+            "description": "runtime error",
+        }
+        message_queue.publish(
+            EventMessage(event_type=event_type, payload=payload, source_agent="tester")
+        )
+
+    assert len(received) == 1
+    diag = received[0]
+    assert "Enter source-code borrowing mode" in diag.actionable_recommendations
+    assert "/src/path" in diag.actionable_recommendations
+    assert diag.details is not None
+    details = cast(dict[str, Any], diag.details)
+    assert details["source_code_paths"] == {"PluginC": "/src/path"}
+    assert details["recommended_skill"] is None
+
+
+@pytest.mark.parametrize("event_type", [ISSUE_DETECTED])
+def test_on_issue_detected_source_code_borrowing_restricted(event_type: str) -> None:
+    message_queue = MessageQueue()
+    received: list[DiagnosisComplete] = []
+    message_queue.subscribe(DIAGNOSIS_COMPLETE, lambda msg: received.append(msg))
+
+    with (
+        patch.object(arch_module, "LibrarianAgent") as MockLib,
+        patch.object(arch_module.Archaeologist, "evaluate_plugin_combo", return_value=False),
+    ):
+        MockLib.return_value.find_skill.return_value = []
+        MockLib.return_value.find_plugin.return_value = ["PluginC"]
+        MockLib.return_value.get_source_code_path.return_value = None
+        Archaeologist(message_queue)
+
+        payload = {
+            "plugin": "test_plugin",
+            "issue_type": "bug",
+            "error_log": "runtime error",
+            "description": "runtime error",
+        }
+        message_queue.publish(
+            EventMessage(event_type=event_type, payload=payload, source_agent="tester")
+        )
+
+    assert len(received) == 1
+    diag = received[0]
+    assert diag.actionable_recommendations == _("New skill development recommended.")
+    assert diag.details is not None
+    details = cast(dict[str, Any], diag.details)
+    assert details["source_code_paths"] == {}
+    assert details["recommended_skill"] is None
+
+
+@pytest.mark.parametrize("event_type", [ISSUE_DETECTED])
 def test_on_issue_detected_with_missing_index(
     event_type: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- allow Archaeologist to search plugin combos, evaluate viability, and borrow source code when needed
- expose LibrarianAgent.find_plugin placeholder
- document new diagnostic decision tree and source borrowing

## Testing
- `pytest tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_existing_skill tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_plugin_combo tests/unit/test_archaeologist_agent.py::test_on_issue_detected_source_code_borrowing_allowed tests/unit/test_archaeologist_agent.py::test_on_issue_detected_source_code_borrowing_restricted -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a70e5b68832f8bd3e30cac43ee05