### PR TITLE
refactor: use attributes for function call

### DIFF
--- a/autogpt/llm/utils/__init__.py
+++ b/autogpt/llm/utils/__init__.py
@@ -10,7 +10,6 @@ from ..api_manager import ApiManager
 from ..base import (
     ChatModelResponse,
     ChatSequence,
-    FunctionCallDict,
     Message,
     ResponseMessageDict,
 )
@@ -171,7 +170,7 @@ def create_chat_completion(
 
     first_message: ResponseMessageDict = response.choices[0].message
     content: str | None = first_message.content
-    function_call: FunctionCallDict | None = first_message.function_call
+    function_call: OpenAIFunctionCall | None = first_message.function_call
 
     for plugin in config.plugins:
         if not plugin.can_handle_on_response():
@@ -183,7 +182,7 @@ def create_chat_completion(
         model_info=OPEN_AI_CHAT_MODELS[model],
         content=content,
         function_call=OpenAIFunctionCall(
-            name=function_call["name"], arguments=function_call["arguments"]
+            name=function_call.name, arguments=function_call.arguments
         )
         if function_call
         else None,


### PR DESCRIPTION
## Summary
- use attribute access for OpenAI function call information

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mlx', etc.)*
- `python - <<'PY'
from types import SimpleNamespace
from unittest.mock import patch
from autogpt.llm.utils import create_chat_completion
from autogpt.llm.base import Message, ChatSequence
from autogpt.config import Config

config = Config()
prompt = ChatSequence.for_model(config.smart_llm, [Message("user", "test")])
fake_response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None, function_call=SimpleNamespace(name="test_func", arguments="{}")))])

def fake_create_chat_completion(*args, **kwargs):
    return fake_response

with patch('autogpt.llm.utils.iopenai.create_chat_completion', fake_create_chat_completion):
    result = create_chat_completion(prompt, config)

print("Function call name:", result.function_call.name)
print("Function call arguments:", result.function_call.arguments)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6894a92bfdfc832fa18e72be50de5e6b