### PR TITLE
Handle unknown models gracefully

### DIFF
--- a/autogpt/llm/api_manager.py
+++ b/autogpt/llm/api_manager.py
@@ -38,7 +38,10 @@ class ApiManager(metaclass=Singleton):
         from autogpt.llm.providers.openai import OPEN_AI_MODELS
 
         model = model[:-3] if model.endswith("-v2") else model
-        model_info = OPEN_AI_MODELS[model]
+        model_info = OPEN_AI_MODELS.get(model)
+        if not model_info:
+            logger.warn("Unknown model %s – skipping cost update", model)
+            return
 
         self.total_prompt_tokens += prompt_tokens
         self.total_completion_tokens += completion_tokens

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,19 @@ sys.modules.setdefault("chromadb", ModuleType("chromadb"))
 sys.modules.setdefault("docx", ModuleType("docx"))
 sys.modules.setdefault("markdown", ModuleType("markdown"))
 sys.modules.setdefault("PyPDF2", ModuleType("PyPDF2"))
+sys.modules.setdefault("faiss", ModuleType("faiss"))
 bs4_stub = ModuleType("bs4")
 bs4_stub.BeautifulSoup = object
 sys.modules.setdefault("bs4", bs4_stub)
 ple_stub = ModuleType("pylatexenc")
 latex2text_stub = ModuleType("pylatexenc.latex2text")
+
+
 class LatexNodes2Text:  # type: ignore
     def latex_to_text(self, s: str) -> str:
         return s
+
+
 latex2text_stub.LatexNodes2Text = LatexNodes2Text
 ple_stub.latex2text = latex2text_stub
 sys.modules.setdefault("pylatexenc", ple_stub)

--- a/tests/unit/test_api_manager.py
+++ b/tests/unit/test_api_manager.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
 
 import pytest
 from pytest_mock import MockerFixture
@@ -76,13 +77,25 @@ class TestApiManager:
         assert api_manager.get_total_cost() == (prompt_tokens * 0.0004) / 1000
 
     @staticmethod
+    def test_update_cost_unknown_model(caplog):
+        """Ensure unknown models do not crash and are ignored."""
+        api_manager.update_cost(100, 50, "unknown-model")
+
+        assert api_manager.get_total_prompt_tokens() == 0
+        assert api_manager.get_total_completion_tokens() == 0
+        assert api_manager.get_total_cost() == 0
+        assert "Unknown model" in caplog.text
+
+    @staticmethod
     def test_get_models():
         """Test if getting models works correctly."""
-        with patch("openai.OpenAI") as mock_openai:
+        with patch("autogpt.llm.providers.openai.OpenAI") as mock_openai:
             mock_client = MagicMock()
-            mock_client.models.list.return_value.data = [{"id": "gpt-3.5-turbo"}]
+            mock_client.models.list.return_value.data = [
+                SimpleNamespace(id="gpt-3.5-turbo")
+            ]
             mock_openai.return_value = mock_client
             result = api_manager.get_models()
 
-            assert result[0]["id"] == "gpt-3.5-turbo"
-            assert api_manager.models[0]["id"] == "gpt-3.5-turbo"
+            assert result[0].id == "gpt-3.5-turbo"
+            assert api_manager.models[0].id == "gpt-3.5-turbo"


### PR DESCRIPTION
## Summary
- avoid crashes when ApiManager sees unknown models
- test skipping of unknown models and mock OpenAI model listing
- stub faiss dependency in tests

## Testing
- `pytest tests/unit/test_api_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6894aa35bf88832fa213521ce25a5fea