### PR TITLE
feat: add code reader and learning phase

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -14,6 +14,7 @@ from autogpt.agents.agent import Agent
 from autogpt.commands.file_operations import write_to_file
 from autogpt.commands.git_operations import git_checkout, git_commit, git_create_branch
 from autogpt.commands.testing import create_test_file, run_tests
+from autogpt.commands.code_reader import read_and_understand_code
 from autogpt.event_bus import (
     DIAGNOSIS_COMPLETE,
     CodeFixProposed,
@@ -43,6 +44,7 @@ class TDDDeveloper:
         self.agent = agent
         self.message_queue = message_queue
         self.librarian = librarian
+        self.learned_sources: dict[str, str] = {}
         self.message_queue.subscribe(DIAGNOSIS_COMPLETE, self._on_diagnosis_complete)
 
     # ------------------------------------------------------------------
@@ -158,6 +160,19 @@ class TDDDeveloper:
 
         if not repo_path:
             return
+
+        # Perform learning phase if source code paths are provided
+        source_paths: dict[str, str] = {}
+        if isinstance(diagnostics, dict):
+            source_paths = diagnostics.get("source_code_paths", {}) or source_paths
+        if isinstance(details, dict) and not source_paths:
+            source_paths = details.get("source_code_paths", {}) or {}
+        for name, lib_path in source_paths.items():
+            try:
+                report = read_and_understand_code(lib_path, self.agent)
+                self.learned_sources[name] = report
+            except Exception:
+                logger.exception("Failed to learn from source path %s", lib_path)
 
         new_skill = details.get("new_skill") if isinstance(details, dict) else None
         if new_skill:

--- a/autogpt/commands/__init__.py
+++ b/autogpt/commands/__init__.py
@@ -1,6 +1,7 @@
 COMMAND_CATEGORIES = [
     "autogpt.commands.execute_code",
     "autogpt.commands.file_operations",
+    "autogpt.commands.code_reader",
     "autogpt.commands.testing",
     "autogpt.commands.web_search",
     "autogpt.commands.web_selenium",

--- a/autogpt/commands/code_reader.py
+++ b/autogpt/commands/code_reader.py
@@ -1,0 +1,69 @@
+"""Commands for reading and understanding code bases."""
+
+from __future__ import annotations
+
+COMMAND_CATEGORY = "code_reader"
+COMMAND_CATEGORY_TITLE = "Code Reader"
+
+from pathlib import Path
+
+from autogpt.agents.agent import Agent
+from autogpt.command_decorator import command
+from autogpt.llm.base import ChatSequence, Message
+from autogpt.llm.utils import create_chat_completion
+
+# Template used to prompt the model for code analysis
+PROMPT_TEMPLATE = (
+    "You are an expert Python developer. Given the following files, provide a "
+    "concise explanation of their purpose and how they work.\n\n{code}\n"
+)
+
+
+@command(
+    "read_and_understand_code",
+    "Read Python files under a path and return a high level summary",
+    {
+        "path": {
+            "type": "string",
+            "description": "Path to a file or directory containing Python code",
+            "required": True,
+        }
+    },
+)
+def read_and_understand_code(path: str, agent: Agent) -> str:
+    """Recursively read `.py` files under ``path`` and summarize their contents."""
+
+    base = Path(path)
+    files: list[Path]
+    if base.is_dir():
+        files = sorted(base.rglob("*.py"))
+    elif base.suffix == ".py":
+        files = [base]
+    else:
+        files = []
+
+    code_parts: list[str] = []
+    for file in files:
+        try:
+            content = file.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        code_parts.append(f"# File: {file.name}\n{content}")
+
+    if not code_parts:
+        return "No Python code found."
+
+    combined = "\n\n".join(code_parts)
+    prompt = ChatSequence.for_model(
+        agent.llm.name,
+        [
+            Message(
+                "system",
+                "You carefully read code and explain it in clear, simple terms.",
+            ),
+            Message("user", PROMPT_TEMPLATE.format(code=combined)),
+        ],
+    )
+
+    response = create_chat_completion(prompt=prompt, config=agent.config)
+    return response.content or ""

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -224,20 +224,23 @@ how to proceed.
 
 1. **Receive diagnostics** – Listen for `DIAGNOSIS_COMPLETE` messages on the
    shared `MessageQueue`.
-2. **Check `recommended_skill`** – If the diagnostics include a
+2. **Learn from borrowed code** – If diagnostics contain `source_code_paths`,
+   the agent invokes `read_and_understand_code` for each provided library path
+   and stores the resulting summaries before proceeding.
+3. **Check `recommended_skill`** – If the diagnostics include a
    `recommended_skill` object, the agent writes a small wrapper script under
    `scripts/use_<name>.py` and a matching test under
    `tests/test_use_<name>.py`. The script loads the skill from
    `skill_library/<name>_<version>/main.py` and invokes its `run` function with
    any provided parameters. The change is committed and a `CODE_FIX_PROPOSED`
    event is published.
-3. **Start TDD skill development** – When no recommendation exists, the agent
+4. **Start TDD skill development** – When no recommendation exists, the agent
    creates a branch and derives failing tests from the diagnostics. It iterates
    on the code until tests pass. If the diagnostics contain a `new_skill`
    payload, the agent scaffolds a new skill in
    `skill_library/<skill_name>_<version>/` and ensures a corresponding
    `skill.json` metadata file is written alongside `main.py`.
-4. **Publish** – Once a usage script or new skill passes its tests, the agent
+5. **Publish** – Once a usage script or new skill passes its tests, the agent
    commits the result and emits `CODE_FIX_PROPOSED` for downstream review.
 
 ### Example wrapper and test

--- a/tests/unit/test_code_reader.py
+++ b/tests/unit/test_code_reader.py
@@ -1,0 +1,31 @@
+import types
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+
+from autogpt.agents.agent import Agent
+from autogpt.commands.code_reader import read_and_understand_code
+
+
+def test_read_and_understand_code_reads_all_files(
+    tmp_path: Path, agent: Agent, mocker: MockerFixture
+) -> None:
+    file1 = tmp_path / "a.py"
+    file1.write_text("print('a')")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    file2 = sub / "b.py"
+    file2.write_text("print('b')")
+
+    mock_resp = types.SimpleNamespace(content="analysis")
+    create_chat = mocker.patch(
+        "autogpt.commands.code_reader.create_chat_completion", return_value=mock_resp
+    )
+
+    result = read_and_understand_code(str(tmp_path), agent)
+
+    assert result == "analysis"
+    create_chat.assert_called_once()
+    prompt = create_chat.call_args[1]["prompt"].messages[1].content
+    assert "print('a')" in prompt
+    assert "print('b')" in prompt

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -327,3 +327,42 @@ def test_tdd_developer_aborts_on_failed_add_skill(
 
     librarian.add_skill.assert_called_once()
     commit.assert_not_called()
+
+
+def test_tdd_developer_learning_phase(
+    agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    event_bus = EventBus(tmp_path / "events.db")
+    message_queue = MessageQueue(event_bus)
+    dev = TDDDeveloper(agent=agent, message_queue=message_queue)
+
+    learn = mocker.patch(
+        "autogpt.agents.tdd_developer.read_and_understand_code", return_value="report"
+    )
+    mocker.patch("autogpt.agents.tdd_developer.git_create_branch", return_value="")
+    mocker.patch("autogpt.agents.tdd_developer.git_checkout", return_value="")
+    mocker.patch(
+        "autogpt.agents.tdd_developer.create_test_file", return_value=""
+    )
+    mocker.patch(
+        "autogpt.agents.tdd_developer.run_tests",
+        return_value={"status": "failed", "exit_code": 1, "successes": 0, "failures": 1, "errors": 0, "logs": ""},
+    )
+    mocker.patch("autogpt.agents.tdd_developer.git_commit", return_value="")
+    mocker.patch("autogpt.agents.tdd_developer.write_to_file", return_value="")
+
+    repo_path = str(workspace.root)
+    payload = {
+        "issue_id": "1",
+        "repo_path": repo_path,
+        "diagnostics": {"source_code_paths": {"lib": str(tmp_path)}}
+    }
+
+    message_queue.publish(
+        EventMessage(
+            event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+        )
+    )
+
+    learn.assert_called_once_with(str(tmp_path), agent)
+    assert dev.learned_sources["lib"] == "report"


### PR DESCRIPTION
## Summary
- add `read_and_understand_code` command to aggregate Python files and summarize them
- integrate learning phase into TDDDeveloper to analyze provided source paths
- document new workflow step and add tests for code reader and learning

## Testing
- `pytest tests/unit/test_code_reader.py tests/unit/test_tdd_developer.py::test_tdd_developer_learning_phase tests/unit/test_tdd_developer.py::test_tdd_developer_handles_diagnosis tests/unit/test_tdd_developer.py::test_tdd_developer_generates_repro_test tests/unit/test_tdd_developer.py::test_tdd_developer_handles_recommended_skill_without_fix_loop tests/unit/test_tdd_developer.py::test_tdd_developer_adds_new_skill tests/unit/test_tdd_developer.py::test_tdd_developer_aborts_on_failed_add_skill -q`

------
https://chatgpt.com/codex/tasks/task_e_6894aa4dbaa4832fb3919a5afe2e713b