### PR TITLE
feat: add read-code subcommand

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -226,7 +226,9 @@ how to proceed.
    shared `MessageQueue`.
 2. **Learn from borrowed code** – If diagnostics contain `source_code_paths`,
    the agent invokes `read_and_understand_code` for each provided library path
-   and stores the resulting summaries before proceeding.
+   and stores the resulting summaries before proceeding. Developers can invoke
+   `python -m scripts.librarian_cli read-code <path>` to generate a similar
+   summary for any local Python project.
 3. **Check `recommended_skill`** – If the diagnostics include a
    `recommended_skill` object, the agent writes a small wrapper script under
    `scripts/use_<name>.py` and a matching test under

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -6,7 +6,9 @@ import argparse
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
+from autogpt.commands.code_reader import read_and_understand_code
 from autogpt.config import Config
 from autogpt.skills import LibrarianAgent
 
@@ -25,13 +27,17 @@ def main() -> None:
     add_p.add_argument("metadata", help="Path to JSON metadata file")
     add_p.add_argument("code", help="Path to Python file containing the skill")
 
+    read_p = sub.add_parser("read-code", help="Summarize Python files under a path")
+    read_p.add_argument("path", help="File or directory to analyze")
+
     src_p = sub.add_parser(
         "source-path", help="Print the source code path for a plugin"
     )
     src_p.add_argument("plugin_name", help="Name of the plugin")
 
     args = parser.parse_args()
-    agent = LibrarianAgent(Config())
+    config = Config()
+    agent = LibrarianAgent(config)
 
     if args.command == "find":
         results = agent.find_skill(args.query, args.k)
@@ -56,6 +62,12 @@ def main() -> None:
             print(path)
         else:
             print("Access denied or plugin not found")
+    elif args.command == "read-code":
+        dummy_agent = SimpleNamespace(
+            config=config, llm=SimpleNamespace(name=config.fast_llm)
+        )
+        report = read_and_understand_code(args.path, dummy_agent)
+        print(report)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- extend `librarian_cli` with a `read-code` command to summarize Python files
- document how to invoke the new command

## Testing
- `pytest tests/unit/test_code_reader.py::test_read_and_understand_code_reads_all_files -q`
- `pre-commit run pytest-check --files scripts/librarian_cli.py docs/architecture/agents.md` *(fails: ModuleNotFoundError: No module named 'jinja2')*


------
https://chatgpt.com/codex/tasks/task_e_6894ad4a4964832fb9124cfa4dafcade