### PR TITLE
feat: track skill approvals

### DIFF
--- a/autogpt/agents/qa_agent.py
+++ b/autogpt/agents/qa_agent.py
@@ -54,6 +54,8 @@ class QAAgent:
             event.payload if isinstance(event.payload, dict) else None
         )
         repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
+        approved_by = (payload or {}).get("approved_by")
+        approval_timestamp = (payload or {}).get("approval_timestamp")
 
         branch = event.branch_name
         if not branch or not repo_path:
@@ -103,6 +105,8 @@ class QAAgent:
             event.payload if isinstance(event.payload, dict) else None
         )
         repo_path = (payload or {}).get("repo_path", self.agent.config.workspace_path)
+        approved_by = (payload or {}).get("approved_by")
+        approval_timestamp = (payload or {}).get("approval_timestamp")
 
         branch = event.branch_name
         if not branch or not repo_path:
@@ -158,6 +162,8 @@ class QAAgent:
                         "Failed to load skill metadata from %s", skill_json_path
                     )
                     continue
+                metadata["approved_by"] = approved_by
+                metadata["approval_timestamp"] = approval_timestamp
                 skill_dir_path = (
                     skill_json_path.parent / metadata.get("entry_point", "main.py")
                 )

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -198,11 +198,15 @@ class ApprovalGranted(EventMessage):
         branch_name: Branch containing the approved fix.
         commit_hash: Hash of the commit that was approved.
         summary: Short description of the approved fix.
+        approved_by: Identity of the approver.
+        approval_timestamp: Timestamp when approval was granted.
     """
 
     branch_name: str
     commit_hash: str
     summary: str
+    approved_by: str | None = None
+    approval_timestamp: str | None = None
     event_type: str = field(init=False, default=APPROVAL_GRANTED)
     payload: dict[str, Any] | str | None = field(init=False)
 
@@ -212,6 +216,10 @@ class ApprovalGranted(EventMessage):
             "commit_hash": self.commit_hash,
             "summary": self.summary,
         }
+        if self.approved_by is not None:
+            self.payload["approved_by"] = self.approved_by
+        if self.approval_timestamp is not None:
+            self.payload["approval_timestamp"] = self.approval_timestamp
 
 
 @dataclass(kw_only=True)

--- a/autogpt/skills/__init__.py
+++ b/autogpt/skills/__init__.py
@@ -36,6 +36,8 @@ def add(
     return_type: str | None = None,
     author_agent: str | None = None,
     creation_timestamp: str | None = None,
+    approved_by: str | None = None,
+    approval_timestamp: str | None = None,
 ) -> Skill:
     """Add a new skill to the library."""
 
@@ -51,6 +53,8 @@ def add(
         return_type,
         author_agent,
         creation_timestamp,
+        approved_by,
+        approval_timestamp,
     )
 
 
@@ -72,6 +76,8 @@ def update(
     return_type: str | None = None,
     author_agent: str | None = None,
     creation_timestamp: str | None = None,
+    approved_by: str | None = None,
+    approval_timestamp: str | None = None,
 ) -> Optional[Skill]:
     """Update an existing skill."""
 
@@ -87,6 +93,8 @@ def update(
         return_type,
         author_agent,
         creation_timestamp,
+        approved_by,
+        approval_timestamp,
     )
 
 

--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -146,6 +146,8 @@ class LibrarianAgent:
                 return_type=metadata.return_type,
                 author_agent=metadata.author_agent,
                 creation_timestamp=metadata.creation_timestamp,
+                approved_by=metadata.approved_by,
+                approval_timestamp=metadata.approval_timestamp,
             )
             return True
         except Exception as err:

--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -36,6 +36,8 @@ class SkillMetadata:
     return_type: str | None = None
     author_agent: str | None = None
     creation_timestamp: str | None = None
+    approved_by: str | None = None
+    approval_timestamp: str | None = None
 
 
 @dataclass
@@ -164,6 +166,8 @@ class SkillLibrary:
                     "return_type": skill.metadata.return_type,
                     "author_agent": skill.metadata.author_agent,
                     "creation_timestamp": skill.metadata.creation_timestamp,
+                    "approved_by": skill.metadata.approved_by,
+                    "approval_timestamp": skill.metadata.approval_timestamp,
                 },
                 f,
                 indent=2,
@@ -219,6 +223,8 @@ class SkillLibrary:
         return_type: str | None = None,
         author_agent: str | None = None,
         creation_timestamp: str | None = None,
+        approved_by: str | None = None,
+        approval_timestamp: str | None = None,
     ) -> Skill:
         """Create and persist a new skill."""
 
@@ -233,6 +239,8 @@ class SkillLibrary:
             return_type,
             author_agent,
             creation_timestamp,
+            approved_by,
+            approval_timestamp,
         )
         skill = Skill(metadata=metadata, code=code)
         text = f"{description}\n{' '.join(tags)}"
@@ -266,6 +274,8 @@ class SkillLibrary:
         return_type: str | None = None,
         author_agent: str | None = None,
         creation_timestamp: str | None = None,
+        approved_by: str | None = None,
+        approval_timestamp: str | None = None,
     ) -> Optional[Skill]:
         key = f"{name}_{version}"
         skill = self._skills.get(key)
@@ -290,6 +300,10 @@ class SkillLibrary:
             skill.metadata.author_agent = author_agent
         if creation_timestamp is not None:
             skill.metadata.creation_timestamp = creation_timestamp
+        if approved_by is not None:
+            skill.metadata.approved_by = approved_by
+        if approval_timestamp is not None:
+            skill.metadata.approval_timestamp = approval_timestamp
 
         text = f"{skill.description}\n{' '.join(skill.tags)}"
         embedding = get_embedding(text, self.config)

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -36,6 +36,8 @@ def _metadata() -> dict:
         "return_type": "str",
         "author_agent": "tester",
         "creation_timestamp": "2024-01-01T00:00:00Z",
+        "approved_by": "qa_tester",
+        "approval_timestamp": "2024-01-02T00:00:00Z",
     }
 
 
@@ -72,6 +74,13 @@ def test_add_and_find_skill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
     results = agent.find_skill("Test skill")
     assert results == [metadata]
+
+    skill_json = (
+        tmp_path / f"{metadata['skill_name']}_{metadata['version']}" / "skill.json"
+    )
+    saved = json.loads(skill_json.read_text(encoding="utf-8"))
+    assert saved["approved_by"] == metadata["approved_by"]
+    assert saved["approval_timestamp"] == metadata["approval_timestamp"]
 
 
 def test_add_skill_invalid_metadata_raises(

--- a/tests/unit/test_qa_agent.py
+++ b/tests/unit/test_qa_agent.py
@@ -311,8 +311,20 @@ def test_qa_agent_registers_new_skills(tmp_path: Path, mocker: MockerFixture) ->
     (skill_dir / "run.py").write_text("def run(): pass", encoding="utf-8")
 
     approval_event = ApprovalGranted(
-        branch_name="fix/123", commit_hash="abc", summary="Fix bug"
+        branch_name="fix/123",
+        commit_hash="abc",
+        summary="Fix bug",
+        approved_by="alice",
+        approval_timestamp="2024-01-02T00:00:00Z",
     )
     on_approval_granted(approval_event)
 
-    librarian.add_skill.assert_called_once_with(metadata, str(skill_dir / "run.py"))
+    expected_metadata = {
+        "name": "Test Skill",
+        "entry_point": "run.py",
+        "approved_by": "alice",
+        "approval_timestamp": "2024-01-02T00:00:00Z",
+    }
+    librarian.add_skill.assert_called_once_with(
+        expected_metadata, str(skill_dir / "run.py")
+    )


### PR DESCRIPTION
## Summary
- extend SkillMetadata to include approver identity and timestamp
- record approval info when QAAgent registers new skills
- persist approval fields in skill.json and expose through LibrarianAgent

## Testing
- `pytest tests/unit/test_librarian_agent.py tests/unit/test_qa_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894afdec7a0832fb58c227ee42e208e