### PR TITLE
Add audit logging for denied plugin source access

### DIFF
--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -12,6 +12,7 @@ from autogpt.logs import logger
 from autogpt.plugins.loader import PluginMetaValidationError, load_plugin_meta
 from autogpt.plugins.models import SourceCodeAccessPolicy
 from autogpt.telemetry import telemetry
+from autogpt.telemetry.audit import log_denied_access
 
 from .library import SkillLibrary, SkillMetadata
 
@@ -157,13 +158,17 @@ class LibrarianAgent:
             ) from err
 
     # ------------------------------------------------------------------
-    def get_source_code_path(self, plugin_name: str) -> str | None:
+    def get_source_code_path(
+        self, plugin_name: str, requester: str | None = None
+    ) -> str | None:
         """Return the local source path for a plugin if access is allowed.
 
         Parameters
         ----------
         plugin_name: str
             Name of the plugin whose source path is requested.
+        requester: str | None
+            Name of the agent requesting access, used for audit logging.
         """
 
         plugins_dir = Path(self.skill_library.config.plugins_dir)
@@ -181,11 +186,7 @@ class LibrarianAgent:
             if policy == SourceCodeAccessPolicy.ALLOWED_FOR_READ_ONLY:
                 return meta.underlying_library.local_source_path
 
-            logger.warn(
-                "Access to source code for plugin '%s' denied by policy '%s'",
-                plugin_name,
-                policy,
-            )
+            log_denied_access(plugin_name, requester or self.__class__.__name__)
             telemetry.increment("get_source_code_path.denied")
             return None
 

--- a/autogpt/telemetry/audit.py
+++ b/autogpt/telemetry/audit.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Simple audit logging for denied access attempts."""
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any
+
+from autogpt.logs import logger
+
+AUDIT_LOG_FILE = Path(__file__).with_suffix('.log')
+
+
+@dataclass
+class AuditEntry:
+    timestamp: str
+    plugin: str
+    agent: str
+
+
+def log_denied_access(plugin: str, agent: str) -> None:
+    """Record a denied access attempt to the audit log."""
+    entry = AuditEntry(
+        timestamp=datetime.utcnow().isoformat(),
+        plugin=plugin,
+        agent=agent,
+    )
+    AUDIT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with AUDIT_LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")
+    logger.warn(
+        "Access to source code for plugin '%s' requested by '%s' denied", plugin, agent
+    )
+
+
+def load_log() -> List[Dict[str, Any]]:
+    """Load audit log entries as a list of dictionaries."""
+    if not AUDIT_LOG_FILE.is_file():
+        return []
+    with AUDIT_LOG_FILE.open("r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -35,6 +35,14 @@ def main() -> None:
     )
     src_p.add_argument("plugin_name", help="Name of the plugin")
 
+    audit_p = sub.add_parser(
+        "audit-log", help="Display or export denied access attempts"
+    )
+    audit_p.add_argument(
+        "--export",
+        help="Path to export audit log in JSON format",
+    )
+
     args = parser.parse_args()
     config = Config()
     agent = LibrarianAgent(config)
@@ -68,6 +76,21 @@ def main() -> None:
         )
         report = read_and_understand_code(args.path, dummy_agent)
         print(report)
+    elif args.command == "audit-log":
+        from autogpt.telemetry.audit import load_log
+
+        entries = load_log()
+        if args.export:
+            Path(args.export).write_text(
+                json.dumps(entries, indent=2), encoding="utf-8"
+            )
+            print(f"Audit log exported to {args.export}")
+        else:
+            if not entries:
+                print("Audit log is empty")
+            else:
+                for entry in entries:
+                    print(json.dumps(entry, indent=2))
     else:
         parser.print_help()
 

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -225,17 +225,22 @@ def test_get_source_code_path_allowed(
 
 
 def test_get_source_code_path_restricted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     plugin_dir, _ = _create_plugin_spec(tmp_path, "restricted", "RESTRICTED")
     agent = _setup_agent(tmp_path, monkeypatch)
     agent.skill_library.config.plugins_dir = str(plugin_dir)
 
-    telemetry.reset()
-    with caplog.at_level("WARNING"):
-        path = agent.get_source_code_path("restricted")
-    assert path is None
-    assert any(
-        "Access to source code for plugin" in rec.message for rec in caplog.records
+    from autogpt.telemetry import audit as audit_module
+
+    monkeypatch.setattr(
+        audit_module, "AUDIT_LOG_FILE", tmp_path / "audit.log", raising=False
     )
+
+    telemetry.reset()
+    path = agent.get_source_code_path("restricted", requester="TestAgent")
+    assert path is None
+    entries = audit_module.load_log()
+    assert entries[-1]["plugin"] == "restricted"
+    assert entries[-1]["agent"] == "TestAgent"
     assert telemetry.get_counts().get("get_source_code_path.denied", 0) == 1


### PR DESCRIPTION
## Summary
- add audit logger to record denied plugin source code requests
- use audit logger in `LibrarianAgent.get_source_code_path`
- expose audit log via `librarian_cli audit-log`
- test that denied requests create audit entries

## Testing
- `pytest tests/unit/test_librarian_agent.py::test_get_source_code_path_allowed tests/unit/test_librarian_agent.py::test_get_source_code_path_restricted -q`

------
https://chatgpt.com/codex/tasks/task_e_6894b3d14f98832fa6f1c0ce81f14d26