### PR TITLE
feat(plugins): track developer and policy maker

### DIFF
--- a/autogpt/plugins/loader.py
+++ b/autogpt/plugins/loader.py
@@ -6,10 +6,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from autogpt.plugins.models import (
-    PluginMeta,
-    PluginMetaValidationError,
-)
+from autogpt.plugins.models import PluginMeta, PluginMetaValidationError
 
 
 def load_plugin_meta(path: str | Path) -> PluginMeta:
@@ -35,8 +32,28 @@ def load_plugin_meta(path: str | Path) -> PluginMeta:
 
     try:
         data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise PluginMetaValidationError(f"Invalid plugin metadata: {e}") from e
+
+    required_fields = {
+        "name",
+        "description",
+        "instructions",
+        "developer",
+        "policy_maker",
+        "underlying_library",
+        "source_code_access_policy",
+    }
+    missing_fields = required_fields.difference(data)
+    if missing_fields:
+        raise PluginMetaValidationError(
+            "Plugin metadata missing required field(s): "
+            + ", ".join(sorted(missing_fields))
+        )
+
+    try:
         meta = PluginMeta.parse_obj(data)
-    except (json.JSONDecodeError, ValidationError) as e:
+    except ValidationError as e:
         raise PluginMetaValidationError(f"Invalid plugin metadata: {e}") from e
 
     source_path = Path(meta.underlying_library.local_source_path).expanduser()

--- a/autogpt/plugins/models.py
+++ b/autogpt/plugins/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+
 from pydantic import BaseModel, HttpUrl
 
 
@@ -26,6 +27,8 @@ class PluginMeta(BaseModel):
     name: str
     description: str
     instructions: str
+    developer: str
+    policy_maker: str
     underlying_library: UnderlyingLibrary
     source_code_access_policy: SourceCodeAccessPolicy
 

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -1,0 +1,18 @@
+# Plugins
+
+Auto-GPT plugins are described by JSON metadata files. These files declare
+what a plugin does and where its code can be found. Each metadata file must
+include the following fields:
+
+- **name** – human readable plugin name.
+- **description** – short explanation of the plugin's purpose.
+- **instructions** – high level guidance on how the plugin should behave.
+- **developer** – individual or organisation that implemented the plugin.
+- **policy_maker** – party responsible for setting usage policies for the plugin.
+- **underlying_library** – object describing the dependency the plugin wraps;
+  requires `name`, `version`, `repo_url` and `local_source_path`.
+- **source_code_access_policy** – one of `ALLOWED_FOR_READ_ONLY` or
+  `RESTRICTED`, describing whether the plugin's source may be inspected.
+
+Missing any of these fields will cause the plugin loader to raise a
+`PluginMetaValidationError` when parsing the metadata file.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -32,6 +32,8 @@ plugin_b:
      "name": "sample",
      "description": "sample plugin",
      "instructions": "describe the behaviour",
+     "developer": "plugin author",
+     "policy_maker": "responsible organisation",
      "underlying_library": {
        "name": "some-lib",
        "version": "1.0.0",
@@ -44,7 +46,8 @@ plugin_b:
 
    其中 `source_code_access_policy` 的可选值为 `ALLOWED_FOR_READ_ONLY` 或
    `RESTRICTED`；`underlying_library` 字段需包含库名称、版本、仓库地址
-   以及本地源码路径。
+   以及本地源码路径。同时还需提供 `developer` 和 `policy_maker` 字段，分别
+   表示插件的开发者和负责其使用策略的主体。
 
 3. 运行以下命令将规范转换为 Python 模块：
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - 插件: plugins.md
   - 架构:
       - 代理: architecture/agents.md
+      - 插件: architecture/plugins.md
   - 配置:
       - 选项: configuration/options.md
       - 搜索: configuration/search.md

--- a/plugins/stubs/echo.spec.json
+++ b/plugins/stubs/echo.spec.json
@@ -2,6 +2,8 @@
   "name": "echo",
   "description": "A simple plugin that echoes input",
   "instructions": "Create a function echo(text: str) -> str that returns text",
+  "developer": "Auto-GPT Maintainers",
+  "policy_maker": "Auto-GPT Maintainers",
   "underlying_library": {
     "name": "python",
     "version": "3.11",

--- a/tests/unit/test_plugin_loader.py
+++ b/tests/unit/test_plugin_loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from autogpt.plugins.loader import load_plugin_meta, PluginMetaValidationError
+from autogpt.plugins.loader import PluginMetaValidationError, load_plugin_meta
 
 
 def test_load_plugin_meta_success(tmp_path: Path) -> None:
@@ -13,6 +13,8 @@ def test_load_plugin_meta_success(tmp_path: Path) -> None:
         "name": "demo",
         "description": "demo plugin",
         "instructions": "do things",
+        "developer": "Auto-GPT",
+        "policy_maker": "Auto-GPT",
         "underlying_library": {
             "name": "lib",
             "version": "0.1",
@@ -33,11 +35,18 @@ def test_load_plugin_meta_missing_field(tmp_path: Path) -> None:
         "name": "demo",
         "description": "demo plugin",
         "instructions": "do things",
+        "developer": "Auto-GPT",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": "src.py",
+        },
         "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
     }
     spec_file = tmp_path / "plugin.json"
     spec_file.write_text(json.dumps(spec))
-    with pytest.raises(PluginMetaValidationError):
+    with pytest.raises(PluginMetaValidationError, match="policy_maker"):
         load_plugin_meta(spec_file)
 
 
@@ -48,6 +57,8 @@ def test_load_plugin_meta_invalid_policy(tmp_path: Path) -> None:
         "name": "demo",
         "description": "demo plugin",
         "instructions": "do things",
+        "developer": "Auto-GPT",
+        "policy_maker": "Auto-GPT",
         "underlying_library": {
             "name": "lib",
             "version": "0.1",


### PR DESCRIPTION
## Summary
- extend plugin metadata with developer and policy_maker fields
- validate required fields when loading plugin specs
- document plugin metadata fields

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files autogpt/plugins/models.py autogpt/plugins/loader.py plugins/stubs/echo.spec.json tests/unit/test_plugin_loader.py docs/architecture/plugins.md docs/plugins.md mkdocs.yml`
- `pytest tests/unit/test_plugin_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6894b471ea48832f850f19f6d88fd81e