### PR TITLE
Add structured logging for code reader and TDD learning

### DIFF
--- a/autogpt/agents/tdd_developer.py
+++ b/autogpt/agents/tdd_developer.py
@@ -171,6 +171,10 @@ class TDDDeveloper:
             try:
                 report = read_and_understand_code(lib_path, self.agent)
                 self.learned_sources[name] = report
+                logger.info(
+                    "learned_source",
+                    extra={"library": name, "path": lib_path},
+                )
             except Exception:
                 logger.exception("Failed to learn from source path %s", lib_path)
 

--- a/autogpt/commands/code_reader.py
+++ b/autogpt/commands/code_reader.py
@@ -6,11 +6,15 @@ COMMAND_CATEGORY = "code_reader"
 COMMAND_CATEGORY_TITLE = "Code Reader"
 
 from pathlib import Path
+import logging
 
 from autogpt.agents.agent import Agent
 from autogpt.command_decorator import command
 from autogpt.llm.base import ChatSequence, Message
 from autogpt.llm.utils import create_chat_completion
+
+logger = logging.getLogger(__name__)
+CALL_COUNT = 0
 
 # Template used to prompt the model for code analysis
 PROMPT_TEMPLATE = (
@@ -33,6 +37,7 @@ PROMPT_TEMPLATE = (
 def read_and_understand_code(path: str, agent: Agent) -> str:
     """Recursively read `.py` files under ``path`` and summarize their contents."""
 
+    global CALL_COUNT
     base = Path(path)
     files: list[Path]
     if base.is_dir():
@@ -41,6 +46,17 @@ def read_and_understand_code(path: str, agent: Agent) -> str:
         files = [base]
     else:
         files = []
+
+    file_count = len(files)
+    CALL_COUNT += 1
+    logger.info(
+        "code_reader",
+        extra={
+            "path_analyzed": str(base),
+            "file_count": file_count,
+            "call_count": CALL_COUNT,
+        },
+    )
 
     code_parts: list[str] = []
     for file in files:

--- a/tests/unit/test_code_reader.py
+++ b/tests/unit/test_code_reader.py
@@ -1,15 +1,18 @@
+import importlib
+import logging
 import types
 from pathlib import Path
 
 from pytest_mock import MockerFixture
 
 from autogpt.agents.agent import Agent
-from autogpt.commands.code_reader import read_and_understand_code
+from autogpt.commands import code_reader
 
 
 def test_read_and_understand_code_reads_all_files(
-    tmp_path: Path, agent: Agent, mocker: MockerFixture
+    tmp_path: Path, agent: Agent, mocker: MockerFixture, caplog
 ) -> None:
+    importlib.reload(code_reader)
     file1 = tmp_path / "a.py"
     file1.write_text("print('a')")
     sub = tmp_path / "sub"
@@ -22,10 +25,16 @@ def test_read_and_understand_code_reads_all_files(
         "autogpt.commands.code_reader.create_chat_completion", return_value=mock_resp
     )
 
-    result = read_and_understand_code(str(tmp_path), agent)
+    with caplog.at_level(logging.INFO):
+        result = code_reader.read_and_understand_code(str(tmp_path), agent)
 
     assert result == "analysis"
     create_chat.assert_called_once()
     prompt = create_chat.call_args[1]["prompt"].messages[1].content
     assert "print('a')" in prompt
     assert "print('b')" in prompt
+
+    assert code_reader.CALL_COUNT == 1
+    record = next(r for r in caplog.records if r.msg == "code_reader")
+    assert record.path_analyzed == str(tmp_path)
+    assert record.file_count == 2

--- a/tests/unit/test_tdd_developer.py
+++ b/tests/unit/test_tdd_developer.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import sys
 import types
 from pathlib import Path
@@ -330,7 +331,11 @@ def test_tdd_developer_aborts_on_failed_add_skill(
 
 
 def test_tdd_developer_learning_phase(
-    agent: Agent, workspace: Workspace, tmp_path: Path, mocker: MockerFixture
+    agent: Agent,
+    workspace: Workspace,
+    tmp_path: Path,
+    mocker: MockerFixture,
+    caplog,
 ) -> None:
     event_bus = EventBus(tmp_path / "events.db")
     message_queue = MessageQueue(event_bus)
@@ -358,11 +363,14 @@ def test_tdd_developer_learning_phase(
         "diagnostics": {"source_code_paths": {"lib": str(tmp_path)}}
     }
 
-    message_queue.publish(
-        EventMessage(
-            event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+    with caplog.at_level(logging.INFO):
+        message_queue.publish(
+            EventMessage(
+                event_type=DIAGNOSIS_COMPLETE, payload=payload, source_agent="tester"
+            )
         )
-    )
 
     learn.assert_called_once_with(str(tmp_path), agent)
     assert dev.learned_sources["lib"] == "report"
+    record = next(r for r in caplog.records if r.msg == "learned_source")
+    assert record.library == "lib"


### PR DESCRIPTION
## Summary
- log code_reader path/file counts and track call count
- record library names when TDDDeveloper learns from code
- test logging behavior and counter increment

## Testing
- `pytest tests/unit/test_code_reader.py tests/unit/test_tdd_developer.py tests/unit/test_tdd_developer_agent.py::test_tdd_developer_agent_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b4747740832fada8d2373640f2b4