### PR TITLE
Handle relative plugin source paths

### DIFF
--- a/autogpt/plugins/loader.py
+++ b/autogpt/plugins/loader.py
@@ -6,10 +6,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from autogpt.plugins.models import (
-    PluginMeta,
-    PluginMetaValidationError,
-)
+from autogpt.plugins.models import PluginMeta, PluginMetaValidationError
 
 
 def load_plugin_meta(path: str | Path) -> PluginMeta:
@@ -39,10 +36,20 @@ def load_plugin_meta(path: str | Path) -> PluginMeta:
     except (json.JSONDecodeError, ValidationError) as e:
         raise PluginMetaValidationError(f"Invalid plugin metadata: {e}") from e
 
+    # Resolve the referenced source path. If a relative path is provided it is
+    # interpreted relative to the metadata file's directory so that specs can be
+    # relocated without breaking their source references.
     source_path = Path(meta.underlying_library.local_source_path).expanduser()
+    if not source_path.is_absolute():
+        source_path = (metadata_path.parent / source_path).resolve()
+
     if not source_path.exists():
         raise PluginMetaValidationError(
             f"local_source_path '{meta.underlying_library.local_source_path}' does not exist"
         )
+
+    # Store the resolved absolute path so consumers always receive a concrete
+    # filesystem location.
+    meta.underlying_library.local_source_path = str(source_path)
 
     return meta

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,7 +44,8 @@ plugin_b:
 
    其中 `source_code_access_policy` 的可选值为 `ALLOWED_FOR_READ_ONLY` 或
    `RESTRICTED`；`underlying_library` 字段需包含库名称、版本、仓库地址
-   以及本地源码路径。
+   以及本地源码路径。`local_source_path` 可以是绝对路径，也可以是
+   相对于该元数据文件的相对路径，但必须指向本地存在的文件。
 
 3. 运行以下命令将规范转换为 Python 模块：
 

--- a/plugins/stubs/echo.spec.json
+++ b/plugins/stubs/echo.spec.json
@@ -6,7 +6,7 @@
     "name": "python",
     "version": "3.11",
     "repo_url": "https://github.com/python/cpython",
-    "local_source_path": "plugins/stubs/echo.spec.json"
+    "local_source_path": "echo.spec.json"
   },
   "source_code_access_policy": "ALLOWED_FOR_READ_ONLY"
 }

--- a/tests/plugins/test_generate_plugins.py
+++ b/tests/plugins/test_generate_plugins.py
@@ -1,10 +1,14 @@
-import json
 import importlib
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+from pytest_mock import MockerFixture
 
-def test_generate_plugins(tmp_path):
-    from scripts.generate_plugins import generate_plugins, AUTO_HEADER
+
+def test_generate_plugins(tmp_path: Path) -> None:
+    from scripts.generate_plugins import AUTO_HEADER, generate_plugins
 
     stubs = tmp_path / "plugins" / "stubs"
     stubs.mkdir(parents=True)
@@ -17,7 +21,7 @@ def test_generate_plugins(tmp_path):
             "name": "python",
             "version": "3.11",
             "repo_url": "https://github.com/python/cpython",
-            "local_source_path": str(spec_file),
+            "local_source_path": spec_file.name,
         },
         "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
     }
@@ -31,7 +35,9 @@ def test_generate_plugins(tmp_path):
     assert AUTO_HEADER.strip() in content
 
 
-def test_llm_generate_uses_chat_completions(mocker, monkeypatch):
+def test_llm_generate_uses_chat_completions(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     spec = {"name": "sample"}
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     import scripts.generate_plugins as gp

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -55,7 +55,7 @@ def _create_plugin_spec(tmp_path: Path, name: str, policy: str) -> tuple[Path, P
             "name": "lib",
             "version": "0.1",
             "repo_url": "https://example.com/lib",
-            "local_source_path": str(source_file),
+            "local_source_path": source_file.name,
         },
         "source_code_access_policy": policy,
     }

--- a/tests/unit/test_plugin_loader.py
+++ b/tests/unit/test_plugin_loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from autogpt.plugins.loader import load_plugin_meta, PluginMetaValidationError
+from autogpt.plugins.loader import PluginMetaValidationError, load_plugin_meta
 
 
 def test_load_plugin_meta_success(tmp_path: Path) -> None:
@@ -17,7 +17,7 @@ def test_load_plugin_meta_success(tmp_path: Path) -> None:
             "name": "lib",
             "version": "0.1",
             "repo_url": "https://example.com/lib",
-            "local_source_path": str(src_file),
+            "local_source_path": src_file.name,
         },
         "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
     }
@@ -25,7 +25,7 @@ def test_load_plugin_meta_success(tmp_path: Path) -> None:
     spec_file.write_text(json.dumps(spec))
     meta = load_plugin_meta(spec_file)
     assert meta.name == "demo"
-    assert meta.underlying_library.local_source_path == str(src_file)
+    assert meta.underlying_library.local_source_path == str(src_file.resolve())
 
 
 def test_load_plugin_meta_missing_field(tmp_path: Path) -> None:
@@ -52,9 +52,28 @@ def test_load_plugin_meta_invalid_policy(tmp_path: Path) -> None:
             "name": "lib",
             "version": "0.1",
             "repo_url": "https://example.com/lib",
-            "local_source_path": str(src),
+            "local_source_path": src.name,
         },
         "source_code_access_policy": "UNKNOWN",
+    }
+    spec_file = tmp_path / "plugin.json"
+    spec_file.write_text(json.dumps(spec))
+    with pytest.raises(PluginMetaValidationError):
+        load_plugin_meta(spec_file)
+
+
+def test_load_plugin_meta_missing_local_source_path(tmp_path: Path) -> None:
+    spec = {
+        "name": "demo",
+        "description": "demo plugin",
+        "instructions": "do things",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": "missing.py",
+        },
+        "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
     }
     spec_file = tmp_path / "plugin.json"
     spec_file.write_text(json.dumps(spec))


### PR DESCRIPTION
## Summary
- resolve and validate plugin `local_source_path` relative to its metadata file
- document new plugin metadata fields and relative path handling
- add tests for relative source paths and missing path errors

## Testing
- `pre-commit run --files autogpt/plugins/loader.py docs/plugins.md plugins/stubs/echo.spec.json tests/plugins/test_generate_plugins.py tests/unit/test_librarian_agent.py tests/unit/test_plugin_loader.py` *(with SKIP=autoflake,pytest-check)*
- `pytest tests/unit/test_plugin_loader.py tests/plugins/test_generate_plugins.py tests/unit/test_librarian_agent.py::test_get_source_code_path_allowed tests/unit/test_librarian_agent.py::test_get_source_code_path_restricted -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b4777ed8832fa9b42056b512f919