### PR TITLE
Clarify plugin source path requirement and test loader validation

### DIFF
--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -10,9 +10,13 @@ include the following fields:
 - **developer** – individual or organisation that implemented the plugin.
 - **policy_maker** – party responsible for setting usage policies for the plugin.
 - **underlying_library** – object describing the dependency the plugin wraps;
-  requires `name`, `version`, `repo_url` and `local_source_path`.
+  requires `name`, `version`, `repo_url` and `local_source_path` (which must
+  point to an existing path on the local filesystem).
 - **source_code_access_policy** – one of `ALLOWED_FOR_READ_ONLY` or
   `RESTRICTED`, describing whether the plugin's source may be inspected.
 
 Missing any of these fields will cause the plugin loader to raise a
 `PluginMetaValidationError` when parsing the metadata file.
+
+In addition to validating required fields, the loader verifies that the
+`local_source_path` referenced in the `underlying_library` actually exists.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -46,7 +46,7 @@ plugin_b:
 
    其中 `source_code_access_policy` 的可选值为 `ALLOWED_FOR_READ_ONLY` 或
    `RESTRICTED`；`underlying_library` 字段需包含库名称、版本、仓库地址
-   以及本地源码路径。同时还需提供 `developer` 和 `policy_maker` 字段，分别
+   以及本地源码路径（该路径必须在本地文件系统中存在）。同时还需提供 `developer` 和 `policy_maker` 字段，分别
    表示插件的开发者和负责其使用策略的主体。
 
 3. 运行以下命令将规范转换为 Python 模块：

--- a/tests/unit/test_plugin_loader.py
+++ b/tests/unit/test_plugin_loader.py
@@ -50,6 +50,27 @@ def test_load_plugin_meta_missing_field(tmp_path: Path) -> None:
         load_plugin_meta(spec_file)
 
 
+def test_load_plugin_meta_missing_source_path(tmp_path: Path) -> None:
+    spec = {
+        "name": "demo",
+        "description": "demo plugin",
+        "instructions": "do things",
+        "developer": "Auto-GPT",
+        "policy_maker": "Auto-GPT",
+        "underlying_library": {
+            "name": "lib",
+            "version": "0.1",
+            "repo_url": "https://example.com/lib",
+            "local_source_path": str(tmp_path / "missing.py"),
+        },
+        "source_code_access_policy": "ALLOWED_FOR_READ_ONLY",
+    }
+    spec_file = tmp_path / "plugin.json"
+    spec_file.write_text(json.dumps(spec))
+    with pytest.raises(PluginMetaValidationError, match="does not exist"):
+        load_plugin_meta(spec_file)
+
+
 def test_load_plugin_meta_invalid_policy(tmp_path: Path) -> None:
     src = tmp_path / "src.py"
     src.write_text("# test")


### PR DESCRIPTION
## Summary
- document that `underlying_library.local_source_path` must point to an existing local path
- mention loader's check for missing source path
- add unit test ensuring missing `local_source_path` raises a clear error

## Testing
- `pytest tests/unit/test_plugin_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c48745bc832fa20463dcf5ab6bec