### PR TITLE
feat: add plugin and skill JSON schemas

### DIFF
--- a/schemas/plugin_schema.json
+++ b/schemas/plugin_schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Significant-Gravitas/AutoGPT/master/schemas/plugin_schema.json",
+  "$comment": "Example: {\"name\": \"Translator\", \"version\": \"1.0.0\", \"description\": \"Translates text\", \"author\": \"AutoGPT\", \"inputs\": [{\"name\": \"text\", \"type\": \"string\", \"description\": \"Text to translate\"}], \"outputs\": [{\"name\": \"translation\", \"type\": \"string\", \"description\": \"Translated text\"}] }",
+  "title": "Plugin Metadata Schema",
+  "type": "object",
+  "required": ["name", "version", "description", "author"],
+  "properties": {
+    "name": {"type": "string"},
+    "version": {"type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$"},
+    "description": {"type": "string"},
+    "author": {"type": "string"},
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": {"type": "string"},
+          "type": {"type": "string"},
+          "description": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": {"type": "string"},
+          "type": {"type": "string"},
+          "description": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/skill_schema.json
+++ b/schemas/skill_schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Significant-Gravitas/AutoGPT/master/schemas/skill_schema.json",
+  "$comment": "Example: {\"name\": \"Summarize\", \"description\": \"Summarizes text\", \"parameters\": {\"text\": {\"type\": \"string\", \"required\": true}}, \"dependencies\": [\"text-preprocess\"]}",
+  "title": "Skill Metadata Schema",
+  "type": "object",
+  "required": ["name", "description"],
+  "properties": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "parameters": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type", "required"],
+        "properties": {
+          "type": {"type": "string"},
+          "required": {"type": "boolean"},
+          "default": {},
+          "description": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add schema definitions for plugin metadata
- add schema definitions for skill metadata

## Testing
- `pre-commit run --files schemas/plugin_schema.json schemas/skill_schema.json` *(fails: ModuleNotFoundError: No module named 'jinja2' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6894c7e306e8832f9da851f3b75530da