### PR TITLE
Add Redis-backed event bus with fallback to SQLite

### DIFF
--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -5,6 +5,9 @@ import sqlite3
 from pathlib import Path
 from typing import Iterable
 
+from .event_bus import connect as redis_connect
+from .event_bus import publish as redis_publish
+from .event_bus import subscribe as redis_subscribe
 from .message_types import (
     APPROVAL_GRANTED,
     CODE_FIX_PROPOSED,
@@ -166,4 +169,7 @@ __all__ = [
     "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
     "DEPLOYMENT_FAILED",
+    "redis_connect",
+    "redis_publish",
+    "redis_subscribe",
 ]

--- a/autogpt/event_bus/event_bus.py
+++ b/autogpt/event_bus/event_bus.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Callable
+
+try:  # pragma: no cover - optional dependency
+    import redis  # type: ignore[import]
+except Exception:  # pragma: no cover - library not available
+    redis = None  # type: ignore
+
+from .message_types import EventMessage
+
+logger = logging.getLogger(__name__)
+
+_client: "redis.Redis | None" = None
+
+
+def connect(
+    host: str | None = None,
+    port: int | None = None,
+    db: int | None = None,
+) -> "redis.Redis | None":
+    """Connect to Redis using environment or config settings."""
+
+    global _client
+
+    if _client:
+        return _client
+    if redis is None:
+        logger.warning("redis-py not installed; Redis event bus disabled.")
+        return None
+
+    host = host or os.getenv("REDIS_HOST")
+    port_env = os.getenv("REDIS_PORT")
+    db_env = os.getenv("REDIS_DB")
+    password = os.getenv("REDIS_PASSWORD")
+
+    if host is None or port is None or db is None or password is None:
+        try:  # pragma: no cover - optional configuration
+            from autogpt.config import Config
+
+            cfg = Config()
+            host = host or cfg.redis_host
+            port = port or cfg.redis_port
+            password = password or cfg.redis_password
+        except Exception:  # pragma: no cover - configuration load failure
+            pass
+
+    host = host or "localhost"
+    port = int(port if port is not None else (port_env or 6379))
+    db = int(db if db is not None else (db_env or 0))
+
+    try:
+        _client = redis.Redis(host=host, port=port, db=db, password=password or None)
+        _client.ping()
+    except Exception as e:  # pragma: no cover - connection failure
+        logger.warning(
+            "Could not connect to Redis (%s:%s, db=%s): %s", host, port, db, e
+        )
+        _client = None
+    return _client
+
+
+def publish(event_type: str, payload: Any) -> None:
+    """Publish ``payload`` under ``event_type`` channel."""
+
+    if _client is None and connect() is None:
+        return
+
+    assert _client is not None  # for type checkers
+
+    if isinstance(payload, EventMessage):
+        data = {
+            "event_type": payload.event_type,
+            "payload": payload.payload,
+            "source_agent": payload.source_agent,
+            "timestamp": payload.timestamp,
+        }
+    else:
+        data = {"event_type": event_type, "payload": payload}
+
+    _client.publish(event_type, json.dumps(data))
+
+
+def subscribe(event_type: str, handler: Callable[[EventMessage], None]) -> None:
+    """Subscribe ``handler`` to messages published under ``event_type``."""
+
+    if _client is None and connect() is None:
+        return
+    assert _client is not None
+
+    pubsub = _client.pubsub()
+
+    def _callback(message: dict[str, Any]) -> None:
+        if message.get("type") != "message":
+            return
+        raw = message.get("data")
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        raw_str = str(raw)
+        try:
+            data = json.loads(raw_str)
+        except Exception:
+            data = {"event_type": event_type, "payload": raw_str}
+        if isinstance(data, dict) and data.get("event_type"):
+            event = EventMessage(
+                event_type=data.get("event_type", event_type),
+                payload=data.get("payload"),
+                source_agent=data.get("source_agent"),
+                timestamp=data.get("timestamp"),
+            )
+        else:
+            event = EventMessage(event_type=event_type, payload=data)
+        handler(event)
+
+    pubsub.subscribe(**{event_type: _callback})
+    pubsub.run_in_thread(daemon=True)
+
+
+__all__ = ["connect", "publish", "subscribe"]

--- a/autogpt/event_bus/message_queue.py
+++ b/autogpt/event_bus/message_queue.py
@@ -14,6 +14,16 @@ except Exception:  # pragma: no cover - library not available
     pub = None
     _HAS_PUBSUB = False
 
+try:  # pragma: no cover - optional dependency
+    from .event_bus import connect as redis_connect
+    from .event_bus import publish as redis_publish
+    from .event_bus import subscribe as redis_subscribe
+
+    _HAS_REDIS = True
+except Exception:  # pragma: no cover - library not available
+    redis_connect = redis_publish = redis_subscribe = None  # type: ignore
+    _HAS_REDIS = False
+
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from . import EventBus
 
@@ -25,9 +35,16 @@ class MessageQueue:
 
     def __init__(self, event_bus: "EventBus" | None = None) -> None:
         self.event_bus = event_bus
-        self._handlers: DefaultDict[str, list[Callable[[EventMessage], None]]] = (
-            defaultdict(list)
-        )
+        self._handlers: DefaultDict[
+            str, list[Callable[[EventMessage], None]]
+        ] = defaultdict(list)
+        self._redis_available = False
+
+        if _HAS_REDIS:
+            try:
+                self._redis_available = redis_connect() is not None
+            except Exception:
+                self._redis_available = False
 
         if not _HAS_PUBSUB:
             logging.getLogger(__name__).warning(
@@ -48,6 +65,15 @@ class MessageQueue:
             for handler in list(self._handlers.get(event_type, [])):
                 handler(event)
 
+        if self._redis_available:
+            try:
+                redis_publish(event_type, event)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "Redis publish failed; disabling Redis event bus."
+                )
+                self._redis_available = False
+
         if self.event_bus:
             self.event_bus.emit(event)
 
@@ -60,6 +86,15 @@ class MessageQueue:
             pub.subscribe(lambda message=None: handler(message), event_type)
         else:
             self._handlers[event_type].append(handler)
+
+        if self._redis_available:
+            try:
+                redis_subscribe(event_type, handler)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "Redis subscribe failed; disabling Redis event bus."
+                )
+                self._redis_available = False
 
     # -- Fallback helpers --------------------------------------------
     def get_events(self, limit: int | None = None) -> Iterable[EventMessage]:


### PR DESCRIPTION
## Summary
- implement Redis-driven event bus with connect/publish/subscribe APIs
- wire MessageQueue to use Redis when available and gracefully fallback
- expose Redis helpers via event_bus package exports

## Testing
- `pre-commit run --files autogpt/event_bus/event_bus.py autogpt/event_bus/message_queue.py autogpt/event_bus/__init__.py` (skipping autoflake,pytest-check)
- `pytest tests/unit/test_event_bus.py`

------
https://chatgpt.com/codex/tasks/task_e_6894caf51784832fa04309859ad2d125