### PR TITLE
feat(event-bus): add skill events

### DIFF
--- a/autogpt/event_bus/__init__.py
+++ b/autogpt/event_bus/__init__.py
@@ -16,6 +16,8 @@ from .message_types import (
     HUMAN_APPROVAL_REQUIRED,
     ISSUE_DETECTED,
     ISSUE_RESOLVED,
+    SKILL_CREATED,
+    SKILL_REQUESTED,
     TESTS_FAILED,
     ApprovalGranted,
     CodeFixProposed,
@@ -24,6 +26,8 @@ from .message_types import (
     EventMessage,
     HumanApprovalRequired,
     IssueResolved,
+    SkillCreated,
+    SkillRequested,
     TestsFailed,
 )
 
@@ -139,6 +143,26 @@ class EventBus:
                     source_agent=source_agent,
                     timestamp=ts,
                 )
+            elif et == SKILL_CREATED and isinstance(payload_obj, dict):
+                yield SkillCreated(
+                    skill_name=str(payload_obj.get("skill_name", "")),
+                    version=str(payload_obj.get("version", "")),
+                    description=payload_obj.get("description"),
+                    tags=payload_obj.get("tags"),
+                    parameters=payload_obj.get("parameters"),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
+            elif et == SKILL_REQUESTED and isinstance(payload_obj, dict):
+                yield SkillRequested(
+                    skill_name=str(payload_obj.get("skill_name", "")),
+                    request_id=payload_obj.get("request_id"),
+                    parameters=payload_obj.get("parameters"),
+                    requester=payload_obj.get("requester"),
+                    context=payload_obj.get("context"),
+                    source_agent=source_agent,
+                    timestamp=ts,
+                )
             else:
                 yield EventMessage(
                     event_type=et,
@@ -161,6 +185,8 @@ __all__ = [
     "ApprovalGranted",
     "IssueResolved",
     "DeploymentFailed",
+    "SkillCreated",
+    "SkillRequested",
     "ISSUE_DETECTED",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
@@ -169,6 +195,8 @@ __all__ = [
     "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
     "DEPLOYMENT_FAILED",
+    "SKILL_CREATED",
+    "SKILL_REQUESTED",
     "redis_connect",
     "redis_publish",
     "redis_subscribe",

--- a/autogpt/event_bus/message_types.py
+++ b/autogpt/event_bus/message_types.py
@@ -43,6 +43,12 @@ TESTS_FAILED = "TESTS_FAILED"
 DEPLOYMENT_FAILED = "DEPLOYMENT_FAILED"
 """Event type emitted when deployment fails."""
 
+SKILL_CREATED = "SKILL_CREATED"
+"""Event type emitted when a new skill is registered."""
+
+SKILL_REQUESTED = "SKILL_REQUESTED"
+"""Event type emitted when an agent requests execution of a skill."""
+
 
 @dataclass(kw_only=True)
 class IssueDetected(EventMessage):
@@ -266,6 +272,68 @@ class DeploymentFailed(EventMessage):
         }
 
 
+@dataclass(kw_only=True)
+class SkillCreated(EventMessage):
+    """Schema for :data:`SKILL_CREATED` events.
+
+    Expected payload fields:
+        skill_name: Name of the created skill.
+        version: Version string of the skill.
+        description: Short summary of what the skill does.
+        tags: Optional list of categorisation tags.
+        parameters: Optional parameter schema for the skill.
+    """
+
+    skill_name: str
+    version: str
+    description: str | None = None
+    tags: list[str] | None = None
+    parameters: dict[str, Any] | None = None
+    event_type: str = field(init=False, default=SKILL_CREATED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "skill_name": self.skill_name,
+            "version": self.version,
+            "description": self.description,
+            "tags": self.tags,
+            "parameters": self.parameters,
+        }
+        self.payload = {k: v for k, v in self.payload.items() if v is not None}
+
+
+@dataclass(kw_only=True)
+class SkillRequested(EventMessage):
+    """Schema for :data:`SKILL_REQUESTED` events.
+
+    Expected payload fields:
+        skill_name: Name of the requested skill.
+        request_id: Optional identifier for the request.
+        parameters: Parameters provided with the request.
+        requester: Identifier of the requesting agent.
+        context: Optional additional context for the request.
+    """
+
+    skill_name: str
+    request_id: str | None = None
+    parameters: dict[str, Any] | None = None
+    requester: str | None = None
+    context: dict[str, Any] | None = None
+    event_type: str = field(init=False, default=SKILL_REQUESTED)
+    payload: dict[str, Any] | str | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.payload = {
+            "skill_name": self.skill_name,
+            "request_id": self.request_id,
+            "parameters": self.parameters,
+            "requester": self.requester,
+            "context": self.context,
+        }
+        self.payload = {k: v for k, v in self.payload.items() if v is not None}
+
+
 __all__ = [
     "EventMessage",
     "IssueDetected",
@@ -276,6 +344,8 @@ __all__ = [
     "ApprovalGranted",
     "IssueResolved",
     "DeploymentFailed",
+    "SkillCreated",
+    "SkillRequested",
     "ISSUE_DETECTED",
     "DIAGNOSIS_COMPLETE",
     "CODE_FIX_PROPOSED",
@@ -284,4 +354,6 @@ __all__ = [
     "APPROVAL_GRANTED",
     "ISSUE_RESOLVED",
     "DEPLOYMENT_FAILED",
+    "SKILL_CREATED",
+    "SKILL_REQUESTED",
 ]

--- a/docs/configuration/message_queue.md
+++ b/docs/configuration/message_queue.md
@@ -76,6 +76,16 @@ A standard message therefore contains:
 }
 ```
 
+Auto-GPT defines additional structured event types. For skills, two relevant
+events are provided:
+
+* **`SKILL_CREATED`** – emitted when a new skill is registered. The payload
+  contains `skill_name`, `version`, optional `description`, `tags`, and
+  `parameters` describing the skill.
+* **`SKILL_REQUESTED`** – emitted when an agent requests execution of a skill.
+  The payload includes `skill_name` as well as optional `request_id`,
+  `parameters`, `requester`, and extra `context`.
+
 ## Examples
 
 ### Publishing an event
@@ -88,6 +98,35 @@ queue = MessageQueue(bus)
 
 queue.publish(
     EventMessage(event_type="status", payload={"msg": "hi"}, source_agent="agent"),
+)
+```
+
+### Publishing skill events
+
+```python
+from autogpt.event_bus import SkillCreated, SkillRequested
+
+# Skill registration
+queue.publish(
+    SkillCreated(
+        skill_name="hello_world",
+        version="1.0",
+        description="Return a friendly greeting",
+        tags=["example"],
+        parameters={},
+        source_agent="librarian",
+    )
+)
+
+# Skill request
+queue.publish(
+    SkillRequested(
+        skill_name="hello_world",
+        request_id="req-1",
+        parameters={},
+        requester="agent",
+        context={"message": "say hi"},
+    )
 )
 ```
 


### PR DESCRIPTION
## Summary
- add `SKILL_CREATED` and `SKILL_REQUESTED` event types with dataclasses
- expose skill events through `EventBus` API and documentation

## Testing
- `pre-commit run --files autogpt/event_bus/message_types.py autogpt/event_bus/__init__.py docs/configuration/message_queue.md`
- `pytest tests/unit/test_event_bus.py` *(fails: No module named 'ftfy')*

------
https://chatgpt.com/codex/tasks/task_e_6894e87e7864832fa9cc13cffb681601