### PR TITLE
feat: add plugin library with semantic search

### DIFF
--- a/autogpt/plugins/library.py
+++ b/autogpt/plugins/library.py
@@ -1,0 +1,114 @@
+"""Library for discovering and searching plugin specifications."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from autogpt.config import Config
+from autogpt.memory.vector.utils import get_embedding
+from autogpt.skills.vector_db import ChromaVectorDB, MemoryVectorDB, VectorDBProvider
+
+
+# ---------------------------------------------------------------------------
+# Data models
+
+
+Embedding = List[float]
+
+
+@dataclass
+class PluginSpec:
+    """Representation of a plugin specification with optional embedding."""
+
+    name: str
+    description: str
+    tags: List[str]
+    spec: Dict
+    embedding: Embedding | None = None
+
+
+class PluginLibrary:
+    """Persist and index plugin specifications for semantic search."""
+
+    def __init__(
+        self,
+        config: Config,
+        repo_path: Path,
+        vector_db: VectorDBProvider | None = None,
+    ) -> None:
+        self.config = config
+        self.repo_path = Path(repo_path)
+        if vector_db is not None:
+            self.vector_db = vector_db
+        else:
+            persist = self.repo_path / "chroma"
+            self.vector_db = ChromaVectorDB(persist, collection_name="plugins")
+        self._plugins: Dict[str, PluginSpec] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        """Load all ``*.spec.json`` files from ``repo_path``."""
+
+        if not self.repo_path.exists():
+            return
+
+        for spec_file in self.repo_path.rglob("*.spec.json"):
+            try:
+                with spec_file.open("r", encoding="utf-8") as f:
+                    spec = json.load(f)
+            except Exception:
+                continue
+            name = spec.get("name")
+            if not name:
+                continue
+            description = spec.get("description", "")
+            tags = spec.get("tags", [])
+            plugin = PluginSpec(name=name, description=description, tags=tags, spec=spec)
+            text = f"{description}\n{' '.join(tags)}"
+            embedding = get_embedding(text, self.config)
+            plugin.embedding = list(map(float, embedding))
+            self._plugins[name] = plugin
+            self.vector_db.add(
+                name,
+                plugin.embedding,
+                {"description": description, "tags": tags},
+            )
+
+    # ------------------------------------------------------------------
+    def reindex(self) -> None:
+        """Clear and rebuild the in-memory index and vector database."""
+
+        self._plugins.clear()
+        try:
+            self.vector_db.clear()
+        except Exception:
+            self.vector_db = MemoryVectorDB()
+        self._load()
+
+    # ------------------------------------------------------------------
+    def get_plugin(self, name: str) -> Optional[PluginSpec]:
+        """Return plugin specification by name if present."""
+
+        return self._plugins.get(name)
+
+    # ------------------------------------------------------------------
+    def list_plugins(self) -> List[PluginSpec]:
+        """Return all loaded plugin specifications."""
+
+        return list(self._plugins.values())
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, top_k: int = 5) -> List[PluginSpec]:
+        """Search for plugins semantically matching ``query``."""
+
+        embedding = get_embedding(query, self.config)
+        results = self.vector_db.query(list(map(float, embedding)), top_k=top_k)
+        return [self._plugins[key] for key, _ in results if key in self._plugins]
+
+
+__all__ = ["PluginSpec", "PluginLibrary"]
+

--- a/tests/unit/test_plugin_library.py
+++ b/tests/unit/test_plugin_library.py
@@ -1,0 +1,66 @@
+"""Tests for :mod:`autogpt.plugins.library`."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from autogpt.config import Config
+
+
+def _make_embedding_map() -> Dict[str, List[float]]:
+    return {
+        "desc1\ntag1": [1.0, 0.0, 0.0],
+        "desc2\ntag2": [0.0, 1.0, 0.0],
+        "desc1": [1.0, 0.0, 0.0],
+        "desc2": [0.0, 1.0, 0.0],
+        "tag1": [1.0, 0.0, 0.0],
+        "tag2": [0.0, 1.0, 0.0],
+    }
+
+
+def test_plugin_library_load_and_search(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    from types import ModuleType
+
+    # Stub out heavy optional dependencies used by get_embedding
+    repo_root = next(Path(p) for p in sys.path if p.endswith("AutoGPT-0.4.7"))
+    vector_pkg = ModuleType("autogpt.memory.vector")
+    vector_pkg.__path__ = [str(repo_root / "autogpt" / "memory" / "vector")]
+    sys.modules.setdefault("autogpt.memory.vector", vector_pkg)
+    sys.modules.setdefault("spacy", ModuleType("spacy"))
+
+    from autogpt.plugins.library import PluginLibrary
+    from autogpt.skills.vector_db import MemoryVectorDB
+
+    config = Config()
+    repo = tmp_path / "plugin_repo"
+    repo.mkdir()
+
+    (repo / "p1.spec.json").write_text(
+        json.dumps({"name": "p1", "description": "desc1", "tags": ["tag1"]})
+    )
+    (repo / "p2.spec.json").write_text(
+        json.dumps({"name": "p2", "description": "desc2", "tags": ["tag2"]})
+    )
+
+    embeddings = _make_embedding_map()
+
+    def fake_get_embedding(text: str, _config: Config) -> List[float]:
+        return embeddings[text]
+
+    monkeypatch.setattr("autogpt.plugins.library.get_embedding", fake_get_embedding)
+
+    library = PluginLibrary(config, repo, vector_db=MemoryVectorDB())
+
+    p1 = library.get_plugin("p1")
+    assert p1 and p1.description == "desc1"
+
+    results = library.search("desc1", top_k=1)
+    assert results and results[0].name == "p1"
+
+    tag_results = library.search("tag2", top_k=1)
+    assert tag_results and tag_results[0].name == "p2"
+


### PR DESCRIPTION
## Summary
- add `PluginLibrary` to index plugin spec files and persist embeddings in ChromaDB
- support semantic search and retrieval of plugin specs
- cover plugin library with unit tests

## Testing
- `pytest tests/unit/test_plugin_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e9775aa4832f89d181d6e3e14c39