### PR TITLE
feat: add plugin library search

### DIFF
--- a/autogpt/plugins/library.py
+++ b/autogpt/plugins/library.py
@@ -23,7 +23,7 @@ Embedding = List[float]
 class PluginSpec:
     """Representation of a plugin specification with optional embedding."""
 
-    name: str
+    id: str
     description: str
     tags: List[str]
     spec: Dict
@@ -62,18 +62,18 @@ class PluginLibrary:
                     spec = json.load(f)
             except Exception:
                 continue
-            name = spec.get("name")
-            if not name:
+            plugin_id = spec.get("id") or spec.get("name")
+            if not plugin_id:
                 continue
             description = spec.get("description", "")
             tags = spec.get("tags", [])
-            plugin = PluginSpec(name=name, description=description, tags=tags, spec=spec)
+            plugin = PluginSpec(id=plugin_id, description=description, tags=tags, spec=spec)
             text = f"{description}\n{' '.join(tags)}"
             embedding = get_embedding(text, self.config)
             plugin.embedding = list(map(float, embedding))
-            self._plugins[name] = plugin
+            self._plugins[plugin_id] = plugin
             self.vector_db.add(
-                name,
+                plugin_id,
                 plugin.embedding,
                 {"description": description, "tags": tags},
             )
@@ -90,10 +90,10 @@ class PluginLibrary:
         self._load()
 
     # ------------------------------------------------------------------
-    def get_plugin(self, name: str) -> Optional[PluginSpec]:
-        """Return plugin specification by name if present."""
+    def get_plugin(self, plugin_id: str) -> Optional[PluginSpec]:
+        """Return plugin specification by identifier if present."""
 
-        return self._plugins.get(name)
+        return self._plugins.get(plugin_id)
 
     # ------------------------------------------------------------------
     def list_plugins(self) -> List[PluginSpec]:
@@ -102,12 +102,12 @@ class PluginLibrary:
         return list(self._plugins.values())
 
     # ------------------------------------------------------------------
-    def search(self, query: str, top_k: int = 5) -> List[PluginSpec]:
-        """Search for plugins semantically matching ``query``."""
+    def search(self, query: str, top_k: int = 5) -> List[str]:
+        """Search for plugins semantically matching ``query`` and return their IDs."""
 
         embedding = get_embedding(query, self.config)
         results = self.vector_db.query(list(map(float, embedding)), top_k=top_k)
-        return [self._plugins[key] for key, _ in results if key in self._plugins]
+        return [key for key, _ in results if key in self._plugins]
 
 
 __all__ = ["PluginSpec", "PluginLibrary"]

--- a/autogpt/skills/librarian.py
+++ b/autogpt/skills/librarian.py
@@ -11,6 +11,7 @@ from autogpt.config import Config
 from autogpt.logs import logger
 from autogpt.plugins.loader import PluginMetaValidationError, load_plugin_meta
 from autogpt.plugins.models import SourceCodeAccessPolicy
+from autogpt.plugins.library import PluginLibrary
 from autogpt.telemetry import telemetry
 from autogpt.telemetry.audit import log_denied_access
 
@@ -21,8 +22,10 @@ class LibrarianAgent:
     """High level interface for managing the skill library."""
 
     def __init__(self, config: Config | None = None) -> None:
-        self.skill_library = SkillLibrary(config or Config())
+        self.config = config or Config()
+        self.skill_library = SkillLibrary(self.config)
         storage = self.skill_library.storage_path
+        self.plugin_library = PluginLibrary(self.config, Path(self.config.plugins_dir))
         if not any(storage.rglob("skill.json")):
             logger.warn(
                 "No existing skill index found at %s; starting with empty library",
@@ -32,6 +35,7 @@ class LibrarianAgent:
         # requests. This keeps ``find_skill`` simple and synchronous while
         # still improving performance for common lookups.
         self._search_cache: Dict[Tuple[str, int], List[dict]] = {}
+        self._plugin_cache: Dict[Tuple[str, int], List[str]] = {}
 
     # ------------------------------------------------------------------
     def find_skill(self, query: str, top_k: int = 3) -> List[dict]:
@@ -85,15 +89,21 @@ class LibrarianAgent:
         return results
 
     # ------------------------------------------------------------------
-    def find_plugin(self, query: str) -> List[str]:
-        """Search for plugins related to ``query``.
+    def find_plugin(self, query: str, top_k: int = 3) -> List[str]:
+        """Search for plugins matching ``query`` and return their identifiers."""
 
-        This is a lightweight placeholder that integrations may override with
-        real plugin discovery. It returns an empty list by default.
-        """
+        cache_key = (query, top_k)
+        if cache_key in self._plugin_cache:
+            cached = self._plugin_cache[cache_key]
+            telemetry.increment(
+                "find_plugin.success" if cached else "find_plugin.failure"
+            )
+            return cached
 
-        telemetry.increment("find_plugin.failure")
-        return []
+        plugin_ids = self.plugin_library.search(query, top_k=top_k)
+        self._plugin_cache[cache_key] = plugin_ids
+        telemetry.increment("find_plugin.success" if plugin_ids else "find_plugin.failure")
+        return plugin_ids
 
     # ------------------------------------------------------------------
     def add_skill(self, skill_metadata: dict, skill_code_path: str) -> bool:

--- a/tests/unit/test_librarian_agent.py
+++ b/tests/unit/test_librarian_agent.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import asdict
 from pathlib import Path
 from types import SimpleNamespace
+from typing import List
 
 import pytest
 
@@ -20,6 +21,15 @@ def _setup_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LibrarianAg
     monkeypatch.setattr(
         "autogpt.skills.librarian.SkillLibrary",
         lambda config: library_module.SkillLibrary(config, storage_path=tmp_path),
+    )
+    from autogpt.plugins import library as plugin_library_module
+    from autogpt.skills.vector_db import MemoryVectorDB
+
+    monkeypatch.setattr(
+        "autogpt.skills.librarian.PluginLibrary",
+        lambda config, _repo_path=None: plugin_library_module.PluginLibrary(
+            config, tmp_path, vector_db=MemoryVectorDB()
+        ),
     )
     return LibrarianAgent(Config())
 
@@ -51,6 +61,8 @@ def _create_plugin_spec(tmp_path: Path, name: str, policy: str) -> tuple[Path, P
         "name": name,
         "description": "Test plugin",
         "instructions": "",
+        "developer": "AutoGPT",
+        "policy_maker": "AutoGPT",
         "underlying_library": {
             "name": "lib",
             "version": "0.1",
@@ -111,6 +123,37 @@ def test_add_skill_missing_code_path_raises(
         with pytest.raises(FileNotFoundError):
             agent.add_skill(metadata, str(missing_path))
     assert any("Skill code path is not a file" in rec.title for rec in caplog.records)
+
+
+def test_find_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "p1.spec.json").write_text(
+        json.dumps({"name": "p1", "description": "desc1", "tags": ["tag1"]})
+    )
+    (tmp_path / "p2.spec.json").write_text(
+        json.dumps({"name": "p2", "description": "desc2", "tags": ["tag2"]})
+    )
+
+    embeddings = {
+        "desc1\ntag1": [1.0, 0.0, 0.0],
+        "desc2\ntag2": [0.0, 1.0, 0.0],
+        "desc1": [1.0, 0.0, 0.0],
+        "desc2": [0.0, 1.0, 0.0],
+        "tag1": [1.0, 0.0, 0.0],
+        "tag2": [0.0, 1.0, 0.0],
+    }
+
+    def fake_get_embedding(text: str, _config: Config) -> List[float]:
+        return embeddings[text]
+
+    monkeypatch.setattr("autogpt.plugins.library.get_embedding", fake_get_embedding)
+
+    agent = _setup_agent(tmp_path, monkeypatch)
+
+    results = agent.find_plugin("desc1", top_k=1)
+    assert results == ["p1"]
+
+    tag_results = agent.find_plugin("tag2", top_k=1)
+    assert tag_results == ["p2"]
 
 
 def test_find_skill_caches_results(

--- a/tests/unit/test_plugin_library.py
+++ b/tests/unit/test_plugin_library.py
@@ -59,8 +59,8 @@ def test_plugin_library_load_and_search(tmp_path: Path, monkeypatch: pytest.Monk
     assert p1 and p1.description == "desc1"
 
     results = library.search("desc1", top_k=1)
-    assert results and results[0].name == "p1"
+    assert results == ["p1"]
 
     tag_results = library.search("tag2", top_k=1)
-    assert tag_results and tag_results[0].name == "p2"
+    assert tag_results == ["p2"]
 


### PR DESCRIPTION
## Summary
- add PluginLibrary to index plugin spec files and search by id
- wire LibrarianAgent to query PluginLibrary for plugin discovery
- expand tests for plugin discovery and plugin library search

## Testing
- `pytest tests/unit/test_plugin_library.py tests/unit/test_librarian_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894efb211b4832fa108ee1a917fc6d0