### PR TITLE
feat(skills): commit skill repos and allow repo path

### DIFF
--- a/autogpt/skills/library.py
+++ b/autogpt/skills/library.py
@@ -87,10 +87,24 @@ class SkillLibrary:
             provider = getattr(config, "skill_db_provider", "memory").lower()
             if provider == "chroma":
                 persist = self.storage_path / "chroma"
-                self.vector_db = ChromaVectorDB(persist)
+                try:
+                    self.vector_db = ChromaVectorDB(persist)
+                except Exception as e:  # pragma: no cover - fallback for missing deps
+                    logger.warn(
+                        "ChromaDB unavailable (%s); falling back to in-memory store",
+                        e,
+                    )
+                    self.vector_db = MemoryVectorDB()
             elif provider == "faiss":
                 persist = self.storage_path / "faiss"
-                self.vector_db = FaissVectorDB(persist)
+                try:
+                    self.vector_db = FaissVectorDB(persist)
+                except Exception as e:  # pragma: no cover - fallback for missing deps
+                    logger.warn(
+                        "Faiss unavailable (%s); falling back to in-memory store",
+                        e,
+                    )
+                    self.vector_db = MemoryVectorDB()
             else:
                 self.vector_db = MemoryVectorDB()
         self._skills: Dict[str, Skill] = {}
@@ -274,7 +288,9 @@ class SkillLibrary:
             {"description": description, "tags": tags, "parameters": parameters},
         )
         skill_dir = self._write_skill(skill)
-        self._git_commit(skill_dir, f"Add skill {name} {version}", repo_path=repo_path)
+        self._git_commit(
+            skill_dir, f"Add skill {name} v{version}", repo_path=repo_path
+        )
         return skill
 
     def get_skill(self, name: str, version: str) -> Optional[Skill]:
@@ -339,7 +355,7 @@ class SkillLibrary:
         )
         skill_dir = self._write_skill(skill)
         self._git_commit(
-            skill_dir, f"Update skill {name} {version}", repo_path=repo_path
+            skill_dir, f"Update skill {name} v{version}", repo_path=repo_path
         )
         return skill
 
@@ -354,7 +370,7 @@ class SkillLibrary:
             if skill_dir.exists():
                 shutil.rmtree(skill_dir)
                 self._git_commit(
-                    skill_dir, f"Delete skill {name} {version}", repo_path=repo_path
+                    skill_dir, f"Delete skill {name} v{version}", repo_path=repo_path
                 )
 
     def list_skills(self) -> List[Skill]:

--- a/scripts/librarian_cli.py
+++ b/scripts/librarian_cli.py
@@ -26,6 +26,10 @@ def main() -> None:
     add_p = sub.add_parser("add", help="Add a new skill")
     add_p.add_argument("metadata", help="Path to JSON metadata file")
     add_p.add_argument("code", help="Path to Python file containing the skill")
+    add_p.add_argument(
+        "--repo-path",
+        help="Path to the skill repository for committing changes",
+    )
 
     read_p = sub.add_parser("read-code", help="Summarize Python files under a path")
     read_p.add_argument("path", help="File or directory to analyze")
@@ -58,7 +62,7 @@ def main() -> None:
         with Path(args.metadata).open("r", encoding="utf-8") as f:
             metadata = json.load(f)
         try:
-            if agent.add_skill(metadata, args.code):
+            if agent.add_skill(metadata, args.code, repo_path=args.repo_path):
                 print("Skill added successfully")
             else:
                 print("Failed to add skill")

--- a/scripts/register_new_skills.py
+++ b/scripts/register_new_skills.py
@@ -13,6 +13,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import argparse
+
 from autogpt.skills import LibrarianAgent
 
 
@@ -50,17 +52,27 @@ def find_new_skill_files(base_ref: str) -> list[Path]:
     return added
 
 
-def register_skill(skill_json: Path, librarian: LibrarianAgent) -> None:
+def register_skill(
+    skill_json: Path, librarian: LibrarianAgent, repo_path: str | Path | None = None
+) -> None:
     """Register a single skill given its ``skill.json`` file."""
     metadata = json.loads(skill_json.read_text(encoding="utf-8"))
     code_path = skill_json.parent / metadata.get("entry_point", "main.py")
-    if librarian.add_skill(metadata, str(code_path)):
+    if librarian.add_skill(metadata, str(code_path), repo_path=repo_path):
         print(f"Registered skill from {skill_json}")
     else:
         print(f"Failed to register skill from {skill_json}")
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Register new skills")
+    parser.add_argument(
+        "--repo-path",
+        default=None,
+        help="Path to the skill repository for committing changes",
+    )
+    args = parser.parse_args()
+
     base_ref = _get_base_ref()
     new_skills = find_new_skill_files(base_ref)
     if not new_skills:
@@ -69,7 +81,7 @@ def main() -> None:
 
     librarian = LibrarianAgent()
     for skill_file in new_skills:
-        register_skill(skill_file, librarian)
+        register_skill(skill_file, librarian, repo_path=args.repo_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fallback to in-memory vector DB when Chroma or Faiss are unavailable
- include version in skill commit messages
- allow specifying skill repo path in librarian and registration CLI tools

## Testing
- `pytest tests/unit/test_skill_library.py::test_git_commit_triggers_push tests/unit/test_skill_library.py::test_git_commit_reports_push_failure`

------
https://chatgpt.com/codex/tasks/task_e_68953c6effb8832f8867c03b9a588bb0