### PR TITLE
feat: evaluate plugin chain with LLM

### DIFF
--- a/autogpt/agents/archaeologist.py
+++ b/autogpt/agents/archaeologist.py
@@ -19,6 +19,8 @@ from autogpt.event_bus import (
 from autogpt.event_bus.message_types import DiagnosisDetails
 from autogpt.logs import logger
 from autogpt.skills.librarian import LibrarianAgent
+from autogpt.llm import ChatSequence, Message
+from autogpt.llm.utils import create_chat_completion
 
 from .archaeologist_dependency import analyze_dependency
 
@@ -50,6 +52,7 @@ class Archaeologist:
             self.librarian = librarian or LibrarianAgent(self.config)
         else:
             self.librarian = None
+        self._combo_eval_cache: dict[tuple[str, ...], bool] = {}
 
     # ------------------------------------------------------------------
     def _on_issue_detected(self, event: EventMessage) -> None:
@@ -394,13 +397,48 @@ class Archaeologist:
         return analyses
 
     def evaluate_plugin_combo(self, plugin_ids: list[str]) -> bool:
-        """Assess whether combining ``plugin_ids`` solves the issue simply.
+        """Assess whether combining ``plugin_ids`` solves the issue simply."""
 
-        This stub always returns ``False``; tests may patch it with heuristic or
-        LLM-backed logic.
-        """
+        key = tuple(plugin_ids)
+        if key in self._combo_eval_cache:
+            return self._combo_eval_cache[key]
 
-        return False
+        lower_ids = [pid.lower() for pid in plugin_ids]
+        input_terms = {"read", "fetch", "get", "search", "load"}
+        output_terms = {"write", "send", "post", "save", "create", "upload"}
+
+        has_input = any(any(term in pid for term in input_terms) for pid in lower_ids)
+        has_output = any(any(term in pid for term in output_terms) for pid in lower_ids)
+
+        if not (has_input and has_output):
+            self._combo_eval_cache[key] = False
+            return False
+
+        prompt = ChatSequence.for_model(
+            self.config.fast_llm,
+            [
+                Message(
+                    "system",
+                    "Evaluate whether chaining these plugins enables problem solving."
+                    " Respond with 'yes' or 'no'.",
+                ),
+                Message(
+                    "user",
+                    f"Plugin chain: {', '.join(plugin_ids)}",
+                ),
+            ],
+        )
+
+        try:
+            response = create_chat_completion(prompt, self.config, temperature=0)
+            content = (response.content or "").strip().lower()
+            result = "yes" in content
+        except Exception as err:  # noqa: BLE001
+            logger.error(f"LLM evaluation failed: {err}")
+            result = False
+
+        self._combo_eval_cache[key] = result
+        return result
 
     def _recommendations(self, analysis: dict[str, Any]) -> str:
         """Create a simple recommendation string from analysis data."""

--- a/tests/unit/test_plugin_combo_eval.py
+++ b/tests/unit/test_plugin_combo_eval.py
@@ -1,0 +1,41 @@
+import autogpt.agents.archaeologist as arch_module
+from autogpt.agents.archaeologist import Archaeologist
+from autogpt.config import Config
+from autogpt.event_bus import MessageQueue
+from autogpt.llm import ChatModelInfo, ChatModelResponse
+
+class DummyResponse(ChatModelResponse):
+    def __init__(self, content: str) -> None:
+        super().__init__(
+            model_info=ChatModelInfo(
+                name="test-model",
+                max_tokens=1000,
+                prompt_token_cost=0.0,
+                completion_token_cost=0.0,
+            ),
+            content=content,
+            function_call=None,
+        )
+
+def test_evaluate_plugin_combo_caches(monkeypatch):
+    calls = {"n": 0}
+    def fake_create(prompt, config, temperature=0, functions=None, model=None, max_tokens=None):
+        calls["n"] += 1
+        return DummyResponse("yes")
+    monkeypatch.setattr(arch_module, "create_chat_completion", fake_create)
+    arch = Archaeologist(MessageQueue(), config=Config(use_librarian=False))
+    plugins = ["fetch_data", "send_email"]
+    assert arch.evaluate_plugin_combo(plugins)
+    assert arch.evaluate_plugin_combo(plugins)
+    assert calls["n"] == 1
+
+def test_evaluate_plugin_combo_heuristic_fail(monkeypatch):
+    calls = {"n": 0}
+    def fake_create(prompt, config, temperature=0, functions=None, model=None, max_tokens=None):
+        calls["n"] += 1
+        return DummyResponse("yes")
+    monkeypatch.setattr(arch_module, "create_chat_completion", fake_create)
+    arch = Archaeologist(MessageQueue(), config=Config(use_librarian=False))
+    plugins = ["analyze_data", "summarize_results"]
+    assert not arch.evaluate_plugin_combo(plugins)
+    assert calls["n"] == 0


### PR DESCRIPTION
## Summary
- implement heuristic and LLM-based plugin combo evaluation with caching
- add unit tests for plugin chain evaluation and cache behavior

## Testing
- `pytest tests/unit/test_plugin_combo_eval.py tests/unit/test_archaeologist_agent.py::test_on_issue_detected_recommends_plugin_combo -q`


------
https://chatgpt.com/codex/tasks/task_e_689558012570832fb101f246e7bf8733