### PR TITLE
Prefer Redis pub/sub for event messaging

### DIFF
--- a/autogpt/event_bus/message_queue.py
+++ b/autogpt/event_bus/message_queue.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
-"""Lightweight publish/subscribe message queue with optional backend."""
+"""Lightweight publish/subscribe message queue."""
 
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable
-
-try:  # pragma: no cover - optional dependency
-    from pubsub import pub
-
-    _HAS_PUBSUB = True
-except Exception:  # pragma: no cover - library not available
-    pub = None
-    _HAS_PUBSUB = False
 
 try:  # pragma: no cover - optional dependency
     from .event_bus import connect as redis_connect
@@ -31,7 +23,7 @@ from .message_types import EventMessage
 
 
 class MessageQueue:
-    """Publish/subscribe queue with graceful fallback."""
+    """Publish/subscribe queue preferring Redis, with SQLite fallback."""
 
     def __init__(self, event_bus: "EventBus" | None = None) -> None:
         self.event_bus = event_bus
@@ -45,12 +37,9 @@ class MessageQueue:
                 self._redis_available = redis_connect() is not None
             except Exception:
                 self._redis_available = False
-
-        if not _HAS_PUBSUB:
-            logging.getLogger(__name__).warning(
-                "PyPubSub not installed; using in-process fallback. "
-                "Install 'pypubsub' or configure an external message queue for "
-                "inter-agent communication."
+        if not self._redis_available:
+            logging.getLogger(__name__).info(
+                "Redis not configured; using in-process message queue."
             )
 
     # -- Core API -----------------------------------------------------
@@ -59,20 +48,18 @@ class MessageQueue:
 
         event_type = event.event_type
 
-        if _HAS_PUBSUB:
-            pub.sendMessage(event_type, message=event)
-        else:
-            for handler in list(self._handlers.get(event_type, [])):
-                handler(event)
-
         if self._redis_available:
             try:
                 redis_publish(event_type, event)
             except Exception:
                 logging.getLogger(__name__).warning(
-                    "Redis publish failed; disabling Redis event bus."
+                    "Redis publish failed; falling back to SQLite."
                 )
                 self._redis_available = False
+
+        if not self._redis_available:
+            for handler in list(self._handlers.get(event_type, [])):
+                handler(event)
 
         if self.event_bus:
             self.event_bus.emit(event)
@@ -82,19 +69,17 @@ class MessageQueue:
     ) -> None:
         """Subscribe ``handler`` to events of ``event_type``."""
 
-        if _HAS_PUBSUB:
-            pub.subscribe(lambda message=None: handler(message), event_type)
-        else:
-            self._handlers[event_type].append(handler)
-
         if self._redis_available:
             try:
                 redis_subscribe(event_type, handler)
             except Exception:
                 logging.getLogger(__name__).warning(
-                    "Redis subscribe failed; disabling Redis event bus."
+                    "Redis subscribe failed; falling back to SQLite."
                 )
                 self._redis_available = False
+                self._handlers[event_type].append(handler)
+        else:
+            self._handlers[event_type].append(handler)
 
     # -- Fallback helpers --------------------------------------------
     def get_events(self, limit: int | None = None) -> Iterable[EventMessage]:

--- a/docs/configuration/message_queue.md
+++ b/docs/configuration/message_queue.md
@@ -1,51 +1,43 @@
 # Message Queue
 
 Auto-GPT includes a lightweight publish/subscribe system for agents to exchange events.
-It consists of a `MessageQueue` for in-memory dispatch and an optional `EventBus`
+It consists of a `MessageQueue` for dispatch and an optional `EventBus`
 that persists events to a SQLite database.
 
 ## Architecture
 
 ```text
-Agent -> MessageQueue -> (PyPubSub backend | in-process fallback) -> Subscribers
+Agent -> MessageQueue -> (Redis Pub/Sub | in-process fallback) -> Subscribers
                                   |
                                   -> EventBus (SQLite)
 ```
 
-* **MessageQueue** – routes messages between agents. If the optional
-  [PyPubSub](https://github.com/schollii/pypubsub) package is installed, it is
-  used as a backend; otherwise Auto-GPT falls back to an internal dispatcher.
+* **MessageQueue** – routes messages between agents. If a Redis connection is
+  configured it is used for Pub/Sub; otherwise Auto-GPT falls back to an
+  internal dispatcher.
 * **EventBus** – persists every event in `events.db` inside the agent's workspace
   for later inspection.
 
 ## Configuration
-
-No configuration is required to use the built‑in queue. Installing PyPubSub
-enables cross-module communication through a shared bus. The event database is
+No configuration is required to use the in‑process queue. The event database is
 created at `<workspace>/events.db` by default.
 
-### Installing the default backend (PyPubSub)
+### Enabling Redis Pub/Sub
 
-Install the optional dependency to enable the PyPubSub backend:
+To share events between processes, provide Redis connection settings via
+environment variables or your configuration file:
 
 ```bash
-pip install agpt[pubsub]  # or: pip install pypubsub
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=yourpassword  # optional
 ```
 
-Once installed, Auto‑GPT will automatically use PyPubSub when creating a
-`MessageQueue`.
-
-### Alternative brokers
-
-You can run an external message broker and provide your own backend
-integration. Example commands to start common brokers locally:
+Run a local Redis instance using Docker:
 
 ```bash
-# Redis
 docker run -p 6379:6379 redis
-
-# RabbitMQ
-docker run -p 5672:5672 rabbitmq
 ```
 
 ## Message format


### PR DESCRIPTION
## Summary
- Prefer Redis for MessageQueue pub/sub, falling back to in-process SQLite
- Document Redis connection options and examples

## Testing
- `pre-commit run --files autogpt/event_bus/message_queue.py docs/configuration/message_queue.md` *(failed: missing dependencies and test collection errors)*


------
https://chatgpt.com/codex/tasks/task_e_68955ea54ac4832fbfa801bb89d3f89c