### PR TITLE
feat: add approval CLI

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -317,7 +317,10 @@ the shared message bus.
 2. **Verify** – It checks out the proposed branch and runs `run_tests` to
    ensure the regression is solved.
 3. **Request approval** – If tests pass, `QAAgent` emits a
-   `HUMAN_APPROVAL_REQUIRED` event to optionally pause for manual review.
+   `HUMAN_APPROVAL_REQUIRED` event to optionally pause for manual review. A
+   human operator can approve the fix by running
+   `python scripts/approve_fix.py --branch <branch> --commit <hash> --summary "..." --approved-by <name>`
+   which publishes an `APPROVAL_GRANTED` event.
 4. **Merge and deploy** – Once approved, the agent merges the branch with
    `git_merge` and can invoke a deployment script before broadcasting
    `ISSUE_RESOLVED`.
@@ -344,6 +347,8 @@ message_queue.publish(EventMessage(CODE_FIX_PROPOSED, payload={"branch": "fix/12
 # QAAgent responds
 run_tests("/path/to/repo", agent)  # -> 'all passed'
 message_queue.publish(EventMessage(HUMAN_APPROVAL_REQUIRED, payload={"branch": "fix/123"}))
+# Operator approves the fix
+# python scripts/approve_fix.py --branch fix/123 --commit abc123 --summary "Example fix" --approved-by alice
 # optional human approval received
 git_merge("/path/to/repo", "fix/123", "main", agent)
 subprocess.run(["./deploy.sh", "fix/123"])

--- a/scripts/approve_fix.py
+++ b/scripts/approve_fix.py
@@ -1,0 +1,55 @@
+"""CLI to publish an ApprovalGranted event once a fix is reviewed."""
+
+from __future__ import annotations
+
+import argparse
+
+from autogpt.event_bus import ApprovalGranted, EventBus, MessageQueue
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Publish an ApprovalGranted event for a reviewed fix"
+    )
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="Branch containing the approved fix",
+    )
+    parser.add_argument(
+        "--commit",
+        required=True,
+        dest="commit_hash",
+        help="Commit hash of the approved fix",
+    )
+    parser.add_argument(
+        "--summary",
+        required=True,
+        help="Short description of the approved fix",
+    )
+    parser.add_argument(
+        "--approved-by",
+        required=True,
+        help="Identifier for the human approver",
+    )
+    parser.add_argument(
+        "--db-path",
+        default="events.db",
+        help="Path to the event database",
+    )
+    args = parser.parse_args()
+
+    bus = EventBus(args.db_path)
+    mq = MessageQueue(bus)
+    event = ApprovalGranted(
+        branch_name=args.branch,
+        commit_hash=args.commit_hash,
+        summary=args.summary,
+        approved_by=args.approved_by,
+    )
+    mq.publish(event)
+    print("ApprovalGranted event published for branch", args.branch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI script to send `ApprovalGranted` events after manual review
- document approval flow and CLI usage in QAAgent docs

## Testing
- `SKIP=autoflake,pytest-check pre-commit run --files scripts/approve_fix.py docs/architecture/agents.md`
- `pytest tests/unit/test_event_bus.py` *(fails: AttributeError: module 'autogpt.event_bus.message_queue' has no attribute '_HAS_PUBSUB')*

------
https://chatgpt.com/codex/tasks/task_e_6895874a815c832fb682f9a79a2956ac